### PR TITLE
fix success phrase pluralization

### DIFF
--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -261,7 +261,8 @@ const ExaltedCharacterManager = () => {
     // Generate action phrase
     let actionPhrase = `Roll ${totalPool}`
     if (totalExtraSuccess > 0) {
-      actionPhrase += `, ${totalExtraSuccess} success in`
+      const successText = totalExtraSuccess === 1 ? "success" : "successes"
+      actionPhrase += `, ${totalExtraSuccess} ${successText}`
     }
     actionPhrase += `, TN ${targetNumber}`
     if (doublesThreshold < 10) {


### PR DESCRIPTION
## Summary
- correctly pluralize extra successes in dice pool action phrase

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68955eddadf483328e710acbd746d29f