### PR TITLE
docs: reference Next.js docs instead of Vite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ This app implements core **Exalted: Essence** mechanics, including:
 - [React Documentation](https://react.dev/)
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/)
 - [Tailwind CSS Docs](https://tailwindcss.com/docs)
-- [Vite Guide](https://vitejs.dev/guide/)
+- [Next.js Documentation](https://nextjs.org/docs)
 
 ---
 


### PR DESCRIPTION
## Summary
- replace Vite guide link with Next.js documentation in contributing guide
- confirm development resources align with project's tech stack

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955eeea0b88332b21a66e3f70dad26