### PR TITLE
chore: add TypeScript ESLint and Prettier plugins

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,9 +11,14 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals"),
+  ...compat.extends("plugin:@typescript-eslint/recommended"),
   {
+    plugins: {
+      prettier: (await import("eslint-plugin-prettier")).default
+    },
     rules: {
-      "react-hooks/exhaustive-deps": "warn"
+      "react-hooks/exhaustive-deps": "warn",
+      "prettier/prettier": "warn"
     }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -103,6 +105,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.4.3",
+    "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "tailwindcss": "^4",


### PR DESCRIPTION
## Summary
- extend ESLint configuration with TypeScript rules and Prettier integration
- declare TypeScript ESLint and Prettier plugins as dev dependencies

## Testing
- `npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-prettier` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: Cannot find package 'eslint-plugin-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_6895743a0f508332a66d9aeb9d8e0b8b