### PR TITLE
refactor: move footer to reusable component

### DIFF
--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { useState, useRef, useCallback, useMemo } from "react"
 import {
   Plus,
   Trash2,
@@ -42,7 +42,6 @@ import { useAutoSave } from "@/hooks/useAutoSave"
 import { useCharacterStore } from "@/hooks/useCharacterStore"
 import type { Character, AttributeType, AbilityType, ArmorPiece } from "@/lib/character-types"
 import { createNewCharacter } from "@/lib/character-defaults"
-import ReactMarkdown from "react-markdown"
 import { toast } from "sonner"
 import { v4 as uuidv4 } from "uuid"
 import {
@@ -59,6 +58,7 @@ import { EquipmentTab } from "@/components/character-tabs/EquipmentTab"
 import { AdvancementTab } from "@/components/character-tabs/AdvancementTab"
 import { CombatTab } from "@/components/character-tabs/CombatTab"
 import { CoreStatsTab } from "@/components/character-tabs/CoreStatsTab"
+import SiteFooter from "@/components/SiteFooter"
 
 // Anima system functions - now imported from utils
 
@@ -80,10 +80,6 @@ const ExaltedCharacterManager = () => {
   const [globalAbilityAttribute, setGlobalAbilityAttribute] = useState<
     AttributeType | "none"
   >("none")
-  const [showAboutModal, setShowAboutModal] = useState(false)
-  const [showLegalModal, setShowLegalModal] = useState(false)
-  const [aboutContent, setAboutContent] = useState("")
-  const [legalContent, setLegalContent] = useState("")
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -92,27 +88,6 @@ const ExaltedCharacterManager = () => {
 
   // Character calculations hook
   const calculations = useCharacterCalculations(currentCharacter)
-
-  // Load markdown content
-  useEffect(() => {
-    const loadMarkdownContent = async () => {
-      try {
-        const aboutResponse = await fetch('/content/about.md')
-        const aboutText = await aboutResponse.text()
-        setAboutContent(aboutText)
-        
-        const legalResponse = await fetch('/content/legal.md')
-        const legalText = await legalResponse.text()
-        setLegalContent(legalText)
-      } catch (error) {
-        setAboutContent('# About\n\nInformation about this application.')
-        setLegalContent('# Legal\n\nLegal information and disclaimers.')
-      }
-    }
-    
-    loadMarkdownContent()
-  }, [])
-
 
   // Character management
   const handleCreateCharacter = useCallback(() => {
@@ -345,8 +320,9 @@ const ExaltedCharacterManager = () => {
 
   if (showCharacterSelect || !currentCharacter) {
     return (
-      <div className="max-w-4xl mx-auto p-6 space-y-6">
-        <Card>
+      <div className="min-h-screen flex flex-col">
+        <div className="max-w-4xl mx-auto p-6 space-y-6 flex-1">
+          <Card>
           <CardHeader>
             <CardTitle className="text-center">Exalted: Essence Character Manager</CardTitle>
             <CardDescription className="text-center">
@@ -497,6 +473,8 @@ const ExaltedCharacterManager = () => {
             )}
           </CardContent>
         </Card>
+        </div>
+        <SiteFooter />
       </div>
     )
   }
@@ -662,78 +640,7 @@ const ExaltedCharacterManager = () => {
         </div>
       </main>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200 px-6 py-4">
-        <div className="max-w-7xl mx-auto flex items-center justify-between text-sm text-gray-600">
-          <div>© 2024 Exalted Character Manager</div>
-          <div className="flex gap-4">
-            <button
-              onClick={() => setShowAboutModal(true)}
-              className="hover:text-gray-800 underline"
-            >
-              About
-            </button>
-            <button
-              onClick={() => setShowLegalModal(true)}
-              className="hover:text-gray-800 underline"
-            >
-              Legal
-            </button>
-          </div>
-        </div>
-      </footer>
-
-      {/* About Modal */}
-      {showAboutModal && (
-        <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-4xl max-h-[80vh] overflow-y-auto m-4">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-xl font-bold">About</h2>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowAboutModal(false)}
-              >
-                ×
-              </Button>
-            </div>
-            <div className="prose prose-sm max-w-none text-gray-700">
-              <ReactMarkdown>{aboutContent}</ReactMarkdown>
-            </div>
-            <div className="mt-6 pt-4 border-t">
-              <Button onClick={() => setShowAboutModal(false)} className="w-full">
-                Close
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Legal Modal */}
-      {showLegalModal && (
-        <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-4xl max-h-[80vh] overflow-y-auto m-4">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-xl font-bold">Legal Information</h2>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowLegalModal(false)}
-              >
-                ×
-              </Button>
-            </div>
-            <div className="prose prose-sm max-w-none text-gray-700">
-              <ReactMarkdown>{legalContent}</ReactMarkdown>
-            </div>
-            <div className="mt-6 pt-4 border-t">
-              <Button onClick={() => setShowLegalModal(false)} className="w-full">
-                Close
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <SiteFooter />
     </div>
   )
 }

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import ReactMarkdown from "react-markdown"
+
+const SiteFooter = () => {
+  const [showAboutModal, setShowAboutModal] = useState(false)
+  const [showLegalModal, setShowLegalModal] = useState(false)
+  const [aboutContent, setAboutContent] = useState("")
+  const [legalContent, setLegalContent] = useState("")
+
+  useEffect(() => {
+    const loadMarkdownContent = async () => {
+      try {
+        const aboutResponse = await fetch("/content/about.md")
+        const aboutText = await aboutResponse.text()
+        setAboutContent(aboutText)
+
+        const legalResponse = await fetch("/content/legal.md")
+        const legalText = await legalResponse.text()
+        setLegalContent(legalText)
+      } catch (error) {
+        setAboutContent("# About\n\nInformation about this application.")
+        setLegalContent("# Legal\n\nLegal information and disclaimers.")
+      }
+    }
+
+    loadMarkdownContent()
+  }, [])
+
+  return (
+    <>
+      <footer className="bg-gray-50 border-t border-gray-200 px-6 py-4">
+        <div className="max-w-7xl mx-auto flex items-center justify-between text-sm text-gray-600">
+          <div>© 2024 Exalted Character Manager</div>
+          <div className="flex gap-4">
+            <button
+              onClick={() => setShowAboutModal(true)}
+              className="hover:text-gray-800 underline"
+            >
+              About
+            </button>
+            <button
+              onClick={() => setShowLegalModal(true)}
+              className="hover:text-gray-800 underline"
+            >
+              Legal
+            </button>
+          </div>
+        </div>
+      </footer>
+
+      {showAboutModal && (
+        <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-4xl max-h-[80vh] overflow-y-auto m-4">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-bold">About</h2>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowAboutModal(false)}
+              >
+                ×
+              </Button>
+            </div>
+            <div className="prose prose-sm max-w-none text-gray-700">
+              <ReactMarkdown>{aboutContent}</ReactMarkdown>
+            </div>
+            <div className="mt-6 pt-4 border-t">
+              <Button onClick={() => setShowAboutModal(false)} className="w-full">
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showLegalModal && (
+        <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-4xl max-h-[80vh] overflow-y-auto m-4">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-bold">Legal Information</h2>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowLegalModal(false)}
+              >
+                ×
+              </Button>
+            </div>
+            <div className="prose prose-sm max-w-none text-gray-700">
+              <ReactMarkdown>{legalContent}</ReactMarkdown>
+            </div>
+            <div className="mt-6 pt-4 border-t">
+              <Button onClick={() => setShowLegalModal(false)} className="w-full">
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default SiteFooter
+


### PR DESCRIPTION
## Summary
- extract footer and modal logic into new `SiteFooter` component
- render `SiteFooter` in character selection view and main layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957636a5948332abebdb9f25f3e6ee