### PR TITLE
feat: add site header and footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 import { ErrorBoundaryWrapper } from "@/components/ErrorBoundary"
+import SiteFooter from "@/components/SiteFooter"
+import SiteHeader from "@/components/SiteHeader"
 import { Toaster } from "sonner"
 
 const geistSans = Geist({
@@ -29,7 +31,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ErrorBoundaryWrapper>
+          <SiteHeader />
           {children}
+          <SiteFooter />
           <Toaster richColors />
         </ErrorBoundaryWrapper>
       </body>

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,9 @@
+export default function SiteFooter() {
+  return (
+    <footer className="border-t bg-background mt-8">
+      <div className="container mx-auto px-4 py-6 text-center text-sm text-muted-foreground">
+        <p>&copy; {new Date().getFullYear()} Exalted Community. All rights reserved.</p>
+      </div>
+    </footer>
+  )
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link"
+
+export default function SiteHeader() {
+  return (
+    <header className="border-b bg-background">
+      <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        <h1 className="text-xl font-semibold">
+          <Link href="/">Exalted: Essence Character Manager</Link>
+        </h1>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable site header and footer components
- include header and footer in root layout for consistent display

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957e78d400833282a3886e706b727f