### PR TITLE
feat: centralize character tab fallback

### DIFF
--- a/components/character-tabs/AdvancementTab.tsx
+++ b/components/character-tabs/AdvancementTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, AdvancementEntry, AdvancementStatus } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface AdvancementTabProps {
   character: Character | null
@@ -85,27 +86,18 @@ export const AdvancementTab: React.FC<AdvancementTabProps> = React.memo(
       return accrued - spent
     }
 
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
-    return (
-      <div className="space-y-6">
-        {/* Milestone Budget */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Milestone Budget</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      return (
+        <CharacterTabWrapper character={character}>
+          {character => (
+            <>
+              {/* Milestone Budget */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Milestone Budget</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
               {/* Personal Milestones */}
               <div className="space-y-3">
                 <Label className="text-sm font-medium text-blue-700">Personal Milestones</Label>
@@ -369,11 +361,13 @@ export const AdvancementTab: React.FC<AdvancementTabProps> = React.memo(
                 </div>
               )}
             </CardContent>
-          )}
-        </Card>
-      </div>
-    )
-  }
+            )}
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 AdvancementTab.displayName = "AdvancementTab"

--- a/components/character-tabs/CharacterTabWrapper.tsx
+++ b/components/character-tabs/CharacterTabWrapper.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import type { Character } from "@/lib/character-types"
+import { cn } from "@/lib/utils"
+
+interface CharacterTabWrapperProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+  character: Character | null
+  children: (character: Character) => React.ReactNode
+}
+
+export const CharacterTabWrapper: React.FC<CharacterTabWrapperProps> = ({
+  character,
+  className,
+  children,
+  ...props
+}) => {
+  if (!character) {
+    return (
+      <div className={cn("space-y-6", className)} {...props}>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-gray-500 italic">No character selected.</p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("space-y-6", className)} {...props}>
+      {children(character)}
+    </div>
+  )
+}
+
+export default CharacterTabWrapper
+

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -20,6 +20,7 @@ import type { Character, ExaltType, DramaticInjury } from "@/lib/character-types
 import { getAnimaLevel, getActiveAnimaRulings, calculateStatTotal } from "@/lib/exalted-utils"
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface CombatTabProps {
   character: Character | null
@@ -101,27 +102,18 @@ export const CombatTab: React.FC<CombatTabProps> = React.memo(
       [character, updateCharacter]
     )
 
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
-    return (
-      <div className="space-y-6">
-        {/* Essence (duplicated for combat convenience) */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Essence</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-6">
+      return (
+        <CharacterTabWrapper character={character}>
+          {character => (
+            <>
+              {/* Essence (duplicated for combat convenience) */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Essence</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid md:grid-cols-2 gap-6">
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <Label>Rating</Label>
@@ -1120,10 +1112,12 @@ export const CombatTab: React.FC<CombatTabProps> = React.memo(
               </div>
             </div>
           </CardContent>
-        </Card>
-      </div>
-    )
-  }
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 CombatTab.displayName = "CombatTab"

--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -21,6 +21,7 @@ import type {
   AbilityType,
 } from "@/lib/character-types"
 import { getAnimaLevel, getActiveAnimaRulings, calculateStatTotal } from "@/lib/exalted-utils"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface CoreStatsTabProps {
   character: Character | null
@@ -46,23 +47,14 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
     globalAbilityAttribute,
     setGlobalAbilityAttribute,
   }) => {
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
     return (
-      <div className="space-y-6">
-        {/* Essence */}
-        <Card>
-          <CardHeader>
+      <CharacterTabWrapper character={character}>
+        {character => (
+          <>
+            {/* Essence */}
+            <Card>
+              <CardHeader>
             <CardTitle>Essence</CardTitle>
           </CardHeader>
           <CardContent>
@@ -853,10 +845,12 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
               </div>
             </div>
           </CardContent>
-        </Card>
-      </div>
-    )
-  }
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 CoreStatsTab.displayName = "CoreStatsTab"

--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -22,6 +22,7 @@ import type {
   WeaponRange,
 } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface EquipmentTabProps {
   character: Character | null
@@ -139,41 +140,32 @@ export const EquipmentTab: React.FC<EquipmentTabProps> = React.memo(
       return tags.join(", ")
     }
 
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
-    return (
-      <div className="space-y-6">
-        {/* Armor */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              Armor
-              <Button onClick={addArmor} size="sm" className="bg-gray-600 hover:bg-gray-700">
-                <Plus className="w-4 h-4 mr-1" />
-                Add Armor
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {(character.armor || []).length === 0 ? (
-              <p className="text-gray-500 italic">No armor equipped.</p>
-            ) : (
-              <div className="space-y-4">
-                {(character.armor || []).map(armor => (
-                  <div
-                    key={armor.id}
-                    className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                  >
+      return (
+        <CharacterTabWrapper character={character}>
+          {character => (
+            <>
+              {/* Armor */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    Armor
+                    <Button onClick={addArmor} size="sm" className="bg-gray-600 hover:bg-gray-700">
+                      <Plus className="w-4 h-4 mr-1" />
+                      Add Armor
+                    </Button>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {(character.armor || []).length === 0 ? (
+                    <p className="text-gray-500 italic">No armor equipped.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {(character.armor || []).map(armor => (
+                        <div
+                          key={armor.id}
+                          className="p-4 bg-white rounded border border-gray-200 space-y-3"
+                        >
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                       <div>
                         <Label htmlFor={`armor-name-${armor.id}`}>Name</Label>
@@ -463,10 +455,12 @@ export const EquipmentTab: React.FC<EquipmentTabProps> = React.memo(
               })()}
             </div>
           </CardContent>
-        </Card>
-      </div>
-    )
-  }
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 EquipmentTab.displayName = "EquipmentTab"

--- a/components/character-tabs/PowersTab.tsx
+++ b/components/character-tabs/PowersTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, Charm, Spell, SpellCircle } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface PowersTabProps {
   character: Character | null
@@ -121,41 +122,32 @@ export const PowersTab: React.FC<PowersTabProps> = React.memo(({ character, upda
     [character, updateCharacter]
   )
 
-  if (!character) {
-    return (
-      <div className="space-y-6">
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-gray-500 italic">No character selected.</p>
-          </CardContent>
-        </Card>
-      </div>
-    )
-  }
 
-  return (
-    <div className="space-y-6">
-      {/* Charms */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            Charms
-            <Button onClick={addCharm} size="sm" className="bg-amber-600 hover:bg-amber-700">
-              <Plus className="w-4 h-4 mr-1" />
-              Add Charm
-            </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {(character.charms || []).length === 0 ? (
-            <p className="text-gray-500 italic">No charms yet.</p>
-          ) : (
-            <div className="space-y-4">
-              {(character.charms || []).map(charm => (
-                <div
-                  key={charm.id}
-                  className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                >
+    return (
+      <CharacterTabWrapper character={character}>
+        {character => (
+          <>
+            {/* Charms */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  Charms
+                  <Button onClick={addCharm} size="sm" className="bg-amber-600 hover:bg-amber-700">
+                    <Plus className="w-4 h-4 mr-1" />
+                    Add Charm
+                  </Button>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {(character.charms || []).length === 0 ? (
+                  <p className="text-gray-500 italic">No charms yet.</p>
+                ) : (
+                  <div className="space-y-4">
+                    {(character.charms || []).map(charm => (
+                      <div
+                        key={charm.id}
+                        className="p-4 bg-white rounded border border-gray-200 space-y-3"
+                      >
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     <div>
                       <Label htmlFor={`charm-name-${charm.id}`}>Name</Label>
@@ -352,9 +344,11 @@ export const PowersTab: React.FC<PowersTabProps> = React.memo(({ character, upda
               ))}
             </div>
           )}
-        </CardContent>
-      </Card>
-    </div>
+          </CardContent>
+        </Card>
+      </>
+    )}
+  </CharacterTabWrapper>
   )
 })
 

--- a/components/character-tabs/RulingsTab.tsx
+++ b/components/character-tabs/RulingsTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, Ruling } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface RulingsTabProps {
   character: Character | null
@@ -65,40 +66,31 @@ export const RulingsTab: React.FC<RulingsTabProps> = React.memo(
       [character, updateCharacter]
     )
 
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
-    return (
-      <div className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              Character-Specific Rulings
-              <Button onClick={addRuling} size="sm">
-                <Plus className="w-4 h-4 mr-1" />
-                Add Ruling
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {(character.rulings || []).length === 0 ? (
-              <p className="text-gray-500 italic">No rulings recorded yet.</p>
-            ) : (
-              <div className="space-y-4">
-                {(character.rulings || []).map(ruling => (
-                  <div
-                    key={ruling.id}
-                    className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                  >
+      return (
+        <CharacterTabWrapper character={character}>
+          {character => (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    Character-Specific Rulings
+                    <Button onClick={addRuling} size="sm">
+                      <Plus className="w-4 h-4 mr-1" />
+                      Add Ruling
+                    </Button>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {(character.rulings || []).length === 0 ? (
+                    <p className="text-gray-500 italic">No rulings recorded yet.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {(character.rulings || []).map(ruling => (
+                        <div
+                          key={ruling.id}
+                          className="p-4 bg-white rounded border border-gray-200 space-y-3"
+                        >
                     <div className="flex items-center gap-2">
                       <div className="flex-1">
                         <Label htmlFor={`title-${ruling.id}`}>Title</Label>
@@ -151,10 +143,12 @@ export const RulingsTab: React.FC<RulingsTabProps> = React.memo(
               </div>
             )}
           </CardContent>
-        </Card>
-      </div>
-    )
-  }
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 RulingsTab.displayName = "RulingsTab"

--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -22,6 +22,7 @@ import type {
   BackgroundLevel,
 } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { CharacterTabWrapper } from "./CharacterTabWrapper"
 
 interface SocialTabProps {
   character: Character | null
@@ -166,22 +167,13 @@ export const SocialTab: React.FC<SocialTabProps> = React.memo(
       [character, updateCharacter]
     )
 
-    if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
-    }
 
-    return (
-      <div className="space-y-6">
-        {/* Social Influence Reference */}
-        <div className="bg-blue-50 rounded-lg p-4 text-xs text-blue-700">
+      return (
+        <CharacterTabWrapper character={character}>
+          {character => (
+            <>
+              {/* Social Influence Reference */}
+              <div className="bg-blue-50 rounded-lg p-4 text-xs text-blue-700">
           <div className="font-semibold mb-1">Social Influence Steps:</div>
           <div>Step 1: The player declares her intention for the influence.</div>
           <div>
@@ -417,10 +409,12 @@ export const SocialTab: React.FC<SocialTabProps> = React.memo(
               </div>
             )}
           </CardContent>
-        </Card>
-      </div>
-    )
-  }
+          </Card>
+        </>
+      )}
+    </CharacterTabWrapper>
+  )
+}
 )
 
 SocialTab.displayName = "SocialTab"


### PR DESCRIPTION
## Summary
- create `CharacterTabWrapper` to handle missing character fallback and allow layout customization
- wrap Core, Combat, Social, and other tabs with the new wrapper

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68958f8efa808332a4fc7abfb6567e7d