### PR TITLE
feat: add reusable stat block editor

### DIFF
--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import StatBlockEditor from "@/components/common/StatBlockEditor"
 import {
   Select,
   SelectContent,
@@ -290,74 +291,24 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                                 ? "text-red-600"
                                 : "text-gray-700"
                         return (
-                          <tr key={key} className="border-b border-gray-200">
-                            <td className={`py-2 px-3 font-medium capitalize ${colorClass}`}>
-                              {key}
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.base}
-                                onChange={e => {
-                                  const value = Math.max(
-                                    1,
-                                    Math.min(5, Number.parseInt(e.target.value) || 1)
-                                  )
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, base: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={1}
-                                max={5}
-                              />
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.added}
-                                onChange={e => {
-                                  const maxAdded = Math.max(0, 5 - attr.base)
-                                  const value = Math.min(
-                                    maxAdded,
-                                    Math.max(0, Number.parseInt(e.target.value) || 0)
-                                  )
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, added: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={0}
-                                max={Math.max(0, 5 - attr.base)}
-                              />
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.bonus}
-                                onChange={e => {
-                                  const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, bonus: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={0}
-                              />
-                            </td>
-                            <td className={`py-2 px-3 font-bold text-center ${colorClass}`}>
-                              {calculateStatTotal(attr)}
-                            </td>
-                          </tr>
+                          <StatBlockEditor
+                            key={key}
+                            label={key}
+                            value={attr}
+                            onChange={updated =>
+                              updateCharacter({
+                                attributes: {
+                                  ...character.attributes,
+                                  [key]: updated,
+                                },
+                              })
+                            }
+                            minBase={1}
+                            maxBase={5}
+                            maxTotal={5}
+                            labelClassName={colorClass}
+                            totalClassName={colorClass}
+                          />
                         )
                       }
                     )}
@@ -436,86 +387,37 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                   </thead>
                   <tbody>
                     {Object.entries(character.abilities || {}).map(
-                      ([key, ability]: [AbilityType, StatBlock]) => (
-                        <tr key={key} className="border-b border-gray-200">
-                          <td className="py-2 px-3 font-medium text-gray-700 text-sm capitalize">
-                            {key.replace(/([A-Z])/g, " $1").trim()}
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.base}
-                              onChange={e => {
-                                const value = Math.max(
-                                  0,
-                                  Math.min(5, Number.parseInt(e.target.value) || 0)
-                                )
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, base: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                              max={5}
-                            />
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.added}
-                              onChange={e => {
-                                const maxAdded = Math.max(0, 5 - ability.base)
-                                const value = Math.min(
-                                  maxAdded,
-                                  Math.max(0, Number.parseInt(e.target.value) || 0)
-                                )
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, added: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                              max={Math.max(0, 5 - ability.base)}
-                            />
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.bonus}
-                              onChange={e => {
-                                const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, bonus: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                            />
-                          </td>
-                          <td
-                            className={`py-2 px-3 font-bold text-center text-sm ${
-                              globalAbilityAttribute === "fortitude"
-                                ? "text-green-600"
-                                : globalAbilityAttribute === "finesse"
-                                  ? "text-blue-600"
-                                  : globalAbilityAttribute === "force"
-                                    ? "text-red-600"
-                                    : "text-gray-700"
-                            }`}
-                          >
-                            {calculateAbilityTotal(key)}
-                          </td>
-                        </tr>
-                      )
+                      ([key, ability]: [AbilityType, StatBlock]) => {
+                        const totalColorClass =
+                          globalAbilityAttribute === "fortitude"
+                            ? "text-green-600"
+                            : globalAbilityAttribute === "finesse"
+                              ? "text-blue-600"
+                              : globalAbilityAttribute === "force"
+                                ? "text-red-600"
+                                : "text-gray-700"
+                        return (
+                          <StatBlockEditor
+                            key={key}
+                            label={key.replace(/([A-Z])/g, " $1").trim()}
+                            value={ability}
+                            onChange={updated =>
+                              updateCharacter({
+                                abilities: {
+                                  ...character.abilities,
+                                  [key]: updated,
+                                },
+                              })
+                            }
+                            minBase={0}
+                            maxBase={5}
+                            maxTotal={5}
+                            labelClassName="text-gray-700 text-sm capitalize"
+                            totalClassName={`text-sm ${totalColorClass}`}
+                            total={calculateAbilityTotal(key)}
+                          />
+                        )
+                      }
                     )}
                   </tbody>
                 </table>

--- a/components/common/StatBlockEditor.tsx
+++ b/components/common/StatBlockEditor.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import { calculateStatTotal } from "@/lib/exalted-utils"
+import type { StatBlock } from "@/lib/character-types"
+import { clamp } from "@/lib/validation"
+
+interface StatBlockEditorProps {
+  label: React.ReactNode
+  value: StatBlock
+  onChange: (value: StatBlock) => void
+  minBase?: number
+  maxBase?: number
+  minAdded?: number
+  maxTotal?: number
+  minBonus?: number
+  maxBonus?: number
+  labelClassName?: string
+  totalClassName?: string
+  total?: number
+}
+
+export const StatBlockEditor: React.FC<StatBlockEditorProps> = ({
+  label,
+  value,
+  onChange,
+  minBase = 0,
+  maxBase = 5,
+  minAdded = 0,
+  maxTotal = 5,
+  minBonus = 0,
+  maxBonus = Infinity,
+  labelClassName,
+  totalClassName,
+  total,
+}) => {
+  const handleBaseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const base = clamp(Number.parseInt(e.target.value) || 0, minBase, maxBase)
+    const added = clamp(value.added, minAdded, Math.max(0, maxTotal - base))
+    onChange({ ...value, base, added })
+  }
+
+  const handleAddedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const maxAdded = Math.max(0, maxTotal - value.base)
+    const added = clamp(Number.parseInt(e.target.value) || 0, minAdded, maxAdded)
+    onChange({ ...value, added })
+  }
+
+  const handleBonusChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const bonus = clamp(Number.parseInt(e.target.value) || 0, minBonus, maxBonus)
+    onChange({ ...value, bonus })
+  }
+
+  return (
+    <tr className="border-b border-gray-200">
+      <td className={cn("py-2 px-3 font-medium capitalize", labelClassName)}>{label}</td>
+      <td className="py-2 px-3">
+        <Input
+          type="number"
+          value={value.base}
+          onChange={handleBaseChange}
+          className="w-16 text-center"
+          min={minBase}
+          max={maxBase}
+        />
+      </td>
+      <td className="py-2 px-3">
+        <Input
+          type="number"
+          value={value.added}
+          onChange={handleAddedChange}
+          className="w-16 text-center"
+          min={minAdded}
+          max={Math.max(0, maxTotal - value.base)}
+        />
+      </td>
+      <td className="py-2 px-3">
+        <Input
+          type="number"
+          value={value.bonus}
+          onChange={handleBonusChange}
+          className="w-16 text-center"
+          min={minBonus}
+          max={maxBonus === Infinity ? undefined : maxBonus}
+        />
+      </td>
+      <td className={cn("py-2 px-3 font-bold text-center", totalClassName)}>
+        {total ?? calculateStatTotal(value)}
+      </td>
+    </tr>
+  )
+}
+
+export default StatBlockEditor

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,3 @@
+export const clamp = (value: number, min: number, max: number): number => {
+  return Math.max(min, Math.min(max, value))
+}


### PR DESCRIPTION
## Summary
- add `StatBlockEditor` component for editing base/added/bonus values with validation
- replace manual attribute and ability inputs in `CoreStatsTab` with `StatBlockEditor` rows
- introduce shared `clamp` utility for numeric bounds

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958f8e8edc8332bef8080370262c09