### PR TITLE
refactor: modularize character manager

### DIFF
--- a/components/CharacterSelect.tsx
+++ b/components/CharacterSelect.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { exportCharacters } from "@/lib/character-storage";
 import {
   Card,
   CardContent,
@@ -127,18 +128,7 @@ export const CharacterSelect: React.FC<CharacterSelectProps> = ({
             {characters.length > 0 && (
               <Button
                 variant="outline"
-                onClick={() => {
-                  const dataStr = JSON.stringify(characters, null, 2);
-                  const dataBlob = new Blob([dataStr], {
-                    type: "application/json",
-                  });
-                  const link = document.createElement("a");
-                  const url = window.URL.createObjectURL(dataBlob);
-                  link.href = url;
-                  link.download = "all_exalted_characters.json";
-                  link.click();
-                  window.URL.revokeObjectURL(url);
-                }}
+                onClick={() => exportCharacters(characters)}
               >
                 <Download className="w-4 h-4 mr-2" />
                 Export All

--- a/components/CharacterTabs.tsx
+++ b/components/CharacterTabs.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { User, Swords, Shield, BookOpen, TrendingUp, Users, Scroll } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { Character, AttributeType, AbilityType } from "@/lib/character-types";
+import { CoreStatsTab } from "@/components/character-tabs/CoreStatsTab";
+import { CombatTab } from "@/components/character-tabs/CombatTab";
+import { EquipmentTab } from "@/components/character-tabs/EquipmentTab";
+import { PowersTab } from "@/components/character-tabs/PowersTab";
+import { SocialTab } from "@/components/character-tabs/SocialTab";
+import { AdvancementTab } from "@/components/character-tabs/AdvancementTab";
+import { RulingsTab } from "@/components/character-tabs/RulingsTab";
+import type { CharacterCalculations } from "@/hooks/useCharacterCalculations";
+import type React from "react";
+
+interface CharacterTabsProps {
+  activeTab: string;
+  onTabChange: (value: string) => void;
+  character: Character;
+  updateCharacter: (updates: Partial<Character>) => void;
+  calculations: CharacterCalculations;
+  calculateSoak: () => number;
+  calculateHardness: () => number;
+  calculateAbilityTotal: (abilityKey: AbilityType) => number;
+  calculateDicePool: () => {
+    basePool: number;
+    extraDice: number;
+    totalPool: number;
+    cappedBonusDice: number;
+    actionPhrase: string;
+  };
+  globalAbilityAttribute: AttributeType | "none";
+  setGlobalAbilityAttribute: (attr: AttributeType | "none") => void;
+  resolve: number;
+}
+
+export function CharacterTabs({
+  activeTab,
+  onTabChange,
+  character,
+  updateCharacter,
+  calculations,
+  calculateSoak,
+  calculateHardness,
+  calculateAbilityTotal,
+  calculateDicePool,
+  globalAbilityAttribute,
+  setGlobalAbilityAttribute,
+  resolve,
+}: CharacterTabsProps) {
+  const tabs = [
+    { id: "core", label: "Core Stats", icon: User },
+    { id: "combat", label: "Combat", icon: Swords },
+    { id: "equipment", label: "Equipment", icon: Shield },
+    { id: "powers", label: "Powers", icon: BookOpen },
+    { id: "socials", label: "Socials", icon: Users },
+    { id: "advancement", label: "Advancement", icon: TrendingUp },
+    { id: "rulings", label: "Rulings", icon: Scroll },
+  ];
+
+  return (
+    <Tabs value={activeTab} onValueChange={onTabChange}>
+      <TabsList className="grid w-full grid-cols-4 lg:grid-cols-8">
+        {tabs.map(tab => {
+          const Icon = tab.icon;
+          return (
+            <TabsTrigger key={tab.id} value={tab.id} className="flex items-center gap-1">
+              <Icon className="w-4 h-4" />
+              <span className="hidden sm:inline">{tab.label}</span>
+            </TabsTrigger>
+          );
+        })}
+      </TabsList>
+
+      <TabsContent value="core" className="space-y-6">
+        <CoreStatsTab
+          character={character}
+          updateCharacter={updateCharacter}
+          calculateAbilityTotal={calculateAbilityTotal}
+          calculateDicePool={calculateDicePool}
+          globalAbilityAttribute={globalAbilityAttribute}
+          setGlobalAbilityAttribute={setGlobalAbilityAttribute}
+        />
+      </TabsContent>
+
+      <TabsContent value="combat" className="space-y-6">
+        <CombatTab
+          character={character}
+          updateCharacter={updateCharacter}
+          calculations={calculations}
+          calculateSoak={calculateSoak}
+          calculateHardness={calculateHardness}
+        />
+      </TabsContent>
+
+      <TabsContent value="equipment" className="space-y-6">
+        <EquipmentTab character={character} updateCharacter={updateCharacter} />
+      </TabsContent>
+
+      <TabsContent value="powers" className="space-y-6">
+        <PowersTab character={character} updateCharacter={updateCharacter} />
+      </TabsContent>
+
+      <TabsContent value="socials" className="space-y-6">
+        <SocialTab character={character} updateCharacter={updateCharacter} resolve={resolve} />
+      </TabsContent>
+
+      <TabsContent value="advancement" className="space-y-6">
+        <AdvancementTab character={character} updateCharacter={updateCharacter} />
+      </TabsContent>
+
+      <TabsContent value="rulings" className="space-y-6">
+        <RulingsTab character={character} updateCharacter={updateCharacter} />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export default CharacterTabs;

--- a/components/CharacterToolbar.tsx
+++ b/components/CharacterToolbar.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRef } from "react";
+import { Download, Upload, User, RefreshCw, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { Character } from "@/lib/character-types";
+
+interface CharacterToolbarProps {
+  character: Character;
+  isSaving: boolean;
+  lastSaved: Date | null;
+  onExport: (character: Character) => Promise<void>;
+  onImport: (file: File) => Promise<void>;
+  onSwitch: () => void;
+}
+
+export function CharacterToolbar({
+  character,
+  isSaving,
+  lastSaved,
+  onExport,
+  onImport,
+  onSwitch,
+}: CharacterToolbarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      await onImport(file);
+      e.target.value = "";
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="flex items-center justify-between p-6">
+        <div className="flex items-center gap-4">
+          <h1 className="text-2xl font-bold">{character.name}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center gap-2 text-sm text-gray-600 cursor-help">
+                  {isSaving ? (
+                    <>
+                      <RefreshCw className="w-4 h-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : lastSaved ? (
+                    <>
+                      <Save className="w-4 h-4" />
+                      Saved {lastSaved.toLocaleTimeString()}
+                    </>
+                  ) : null}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Characters are automatically saved to your browser&apos;s local storage every 10 minutes</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          <Button variant="outline" size="sm" onClick={() => onExport(character)}>
+            <Download className="w-4 h-4 mr-1" />
+            Export
+          </Button>
+
+          <Button variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
+            <Upload className="w-4 h-4 mr-1" />
+            Import
+          </Button>
+
+          <Button variant="outline" size="sm" onClick={onSwitch}>
+            <User className="w-4 h-4 mr-1" />
+            Switch
+          </Button>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".json"
+          onChange={handleImport}
+          className="hidden"
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default CharacterToolbar;

--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -1,166 +1,55 @@
-"use client"
+"use client";
 
-import type React from "react"
-import { useState, useRef, useCallback } from "react"
-import {
-  User,
-  Download,
-  Upload,
-  Shield,
-  Swords,
-  BookOpen,
-  TrendingUp,
-  Users,
-  Scroll,
-  Save,
-  RefreshCw,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import CharacterSelect from "@/components/CharacterSelect"
-import { useCharacterCalculations } from "@/hooks/useCharacterCalculations"
-import { useAutoSave } from "@/hooks/useAutoSave"
-import { useCharacterStore } from "@/hooks/useCharacterStore"
-import type { Character, AttributeType, AbilityType, ArmorPiece } from "@/lib/character-types"
-import { createNewCharacter } from "@/lib/character-defaults"
-import { toast } from "sonner"
-import { v4 as uuidv4 } from "uuid"
-import {
-  getAnimaLevel,
-  getActiveAnimaRulings,
-  calculateStatTotal,
-  clampModifier,
-} from "@/lib/exalted-utils"
-import { RulingsTab } from "@/components/character-tabs/RulingsTab"
-import { PowersTab } from "@/components/character-tabs/PowersTab"
-import { SocialTab } from "@/components/character-tabs/SocialTab"
-import { EquipmentTab } from "@/components/character-tabs/EquipmentTab"
-import { AdvancementTab } from "@/components/character-tabs/AdvancementTab"
-import { CombatTab } from "@/components/character-tabs/CombatTab"
-import { CoreStatsTab } from "@/components/character-tabs/CoreStatsTab"
+import { useRef, useState } from "react";
+import CharacterSelect from "@/components/CharacterSelect";
+import CharacterToolbar from "@/components/CharacterToolbar";
+import CharacterTabs from "@/components/CharacterTabs";
+import { useAutoSave } from "@/hooks/useAutoSave";
+import { useCharacterCalculations } from "@/hooks/useCharacterCalculations";
+import { useCharacterManagement } from "@/hooks/useCharacterManagement";
+import type {
+  Character,
+  AttributeType,
+  AbilityType,
+  ArmorPiece,
+} from "@/lib/character-types";
+import { calculateStatTotal } from "@/lib/exalted-utils";
+import { importCharacters, exportCharacter } from "@/lib/character-storage";
+import { toast } from "sonner";
 
-// Anima system functions - now imported from utils
-
-// Main component
 const ExaltedCharacterManager = () => {
   const {
     characters,
     currentCharacter,
-    addCharacter,
-    updateCurrentCharacter,
+    showCharacterSelect,
+    setShowCharacterSelect,
+    createCharacter,
+    selectCharacter,
+    updateCharacter,
     deleteCharacter,
-    setCurrentCharacter,
     loadCharacters,
-  } = useCharacterStore()
-  const [showCharacterSelect, setShowCharacterSelect] = useState(true)
-  const [activeTab, setActiveTab] = useState("core")
-  const [globalAbilityAttribute, setGlobalAbilityAttribute] = useState<AttributeType | "none">(
-    "none"
-  )
+  } = useCharacterManagement();
 
-  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [activeTab, setActiveTab] = useState("core");
+  const [globalAbilityAttribute, setGlobalAbilityAttribute] =
+    useState<AttributeType | "none">("none");
 
-  // Auto-save functionality
-  const { isSaving, lastSaved } = useAutoSave(characters, "exalted-characters")
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Character calculations hook
-  const calculations = useCharacterCalculations(currentCharacter)
+  const { isSaving, lastSaved } = useAutoSave(characters, "exalted-characters");
+  const calculations = useCharacterCalculations(currentCharacter);
 
-  // Load markdown content
+  const calculateAbilityTotal = (abilityKey: AbilityType) => {
+    const ability = currentCharacter?.abilities?.[abilityKey];
+    if (!ability) return 0;
+    const abilityTotal = calculateStatTotal(ability);
+    if (!globalAbilityAttribute || globalAbilityAttribute === "none") return abilityTotal;
+    const attribute = currentCharacter?.attributes?.[globalAbilityAttribute];
+    if (!attribute) return abilityTotal;
+    return abilityTotal + calculateStatTotal(attribute);
+  };
 
-  // Character management
-    const createCharacter = useCallback(
-    (name: string) => {
-      if (!name.trim()) return
-      addCharacter(name.trim())
-      setShowCharacterSelect(false)
-    },
-    [addCharacter]
-  )
-
-  const selectCharacter = useCallback(
-    (id: string) => {
-      setCurrentCharacter(id)
-      setShowCharacterSelect(false)
-    },
-    [setCurrentCharacter]
-  )
-
-  const updateCharacter = useCallback(
-    (updates: Partial<Character>) => {
-      updateCurrentCharacter(updates)
-    },
-    [updateCurrentCharacter]
-  )
-
-  // Calculation functions
-  // Using calculateStatTotal from utils instead of inline function
-
-  const getHighestAttribute = useCallback(() => {
-    if (!currentCharacter?.attributes) return 0
-    return calculations.highestAttribute
-  }, [currentCharacter?.attributes, calculations.highestAttribute])
-
-  const calculateEvasion = useCallback(() => {
-    return calculations.evasion
-  }, [calculations.evasion])
-
-  const calculateParry = useCallback(() => {
-    return calculations.parry
-  }, [calculations.parry])
-
-  const calculateDefense = useCallback(() => {
-    return calculations.defense
-  }, [calculations.defense])
-
-  const calculateResolve = useCallback(() => {
-    return calculations.resolve
-  }, [calculations.resolve])
-
-  const calculateSoak = useCallback(() => {
-    if (!currentCharacter?.abilities?.physique) return 1
-    const physique = calculateStatTotal(currentCharacter.abilities.physique)
-    let base = 1
-    if (physique >= 3) base += 1
-    const armorSoak = (currentCharacter?.armor || []).reduce(
-      (total: number, armor: ArmorPiece) => total + (Number.parseInt(String(armor.soak)) || 0),
-      0
-    )
-    const modifier = currentCharacter?.staticValues?.soakModifier || 0
-    return Math.max(0, base + armorSoak + Math.max(-5, Math.min(5, modifier)))
-  }, [currentCharacter])
-
-  const calculateHardness = useCallback(() => {
-    const essence = currentCharacter?.essence?.rating || 1
-    const base = essence + 2
-    const armorHardness = (currentCharacter?.armor || []).reduce(
-      (total: number, armor: ArmorPiece) => total + (Number.parseInt(String(armor.hardness)) || 0),
-      0
-    )
-    const modifier = currentCharacter?.staticValues?.hardnessModifier || 0
-    return Math.max(0, base + armorHardness + Math.max(-5, Math.min(5, modifier)))
-  }, [currentCharacter])
-
-  const calculateAbilityTotal = useCallback(
-    (abilityKey: AbilityType) => {
-      const ability = currentCharacter?.abilities?.[abilityKey]
-      if (!ability) return 0
-
-      const abilityTotal = calculateStatTotal(ability)
-
-      if (!globalAbilityAttribute || globalAbilityAttribute === "none") return abilityTotal
-
-      const attribute = currentCharacter?.attributes?.[globalAbilityAttribute]
-      if (!attribute) return abilityTotal
-
-      return abilityTotal + calculateStatTotal(attribute)
-    },
-    [currentCharacter, globalAbilityAttribute]
-  )
-
-  const calculateDicePool = useCallback(() => {
+  const calculateDicePool = () => {
     if (
       !currentCharacter?.dicePool ||
       !currentCharacter?.attributes ||
@@ -172,9 +61,8 @@ const ExaltedCharacterManager = () => {
         totalPool: 0,
         cappedBonusDice: 0,
         actionPhrase: "Roll 0, TN 7 Double 10s",
-      }
+      };
     }
-
     const {
       attribute,
       ability,
@@ -182,123 +70,88 @@ const ExaltedCharacterManager = () => {
       doublesThreshold,
       extraSuccessBonus,
       extraSuccessNonBonus,
-    } = currentCharacter.dicePool
+    } = currentCharacter.dicePool;
     const attributeTotal = calculateStatTotal(
-      currentCharacter.attributes[attribute] || { base: 0, added: 0, bonus: 0 }
-    )
+      currentCharacter.attributes[attribute] || { base: 0, added: 0, bonus: 0 },
+    );
     const abilityTotal = calculateStatTotal(
-      currentCharacter.abilities[ability] || { base: 0, added: 0, bonus: 0 }
-    )
-    const basePool = attributeTotal + abilityTotal
-
-    const { extraDiceBonus, extraDiceNonBonus, isStunted } = currentCharacter.dicePool
-    const cappedBonusDice = Math.min(extraDiceBonus || 0, 10)
-    const stuntDice = isStunted ? 2 : 0
-    const totalExtraDice = cappedBonusDice + (extraDiceNonBonus || 0) + stuntDice
-    const totalPool = basePool + totalExtraDice
-
-    const totalExtraSuccess = (extraSuccessBonus || 0) + (extraSuccessNonBonus || 0)
-
-    // Generate action phrase
-    let actionPhrase = `Roll ${totalPool}`
+      currentCharacter.abilities[ability] || { base: 0, added: 0, bonus: 0 },
+    );
+    const basePool = attributeTotal + abilityTotal;
+    const { extraDiceBonus, extraDiceNonBonus, isStunted } = currentCharacter.dicePool;
+    const cappedBonusDice = Math.min(extraDiceBonus || 0, 10);
+    const stuntDice = isStunted ? 2 : 0;
+    const totalExtraDice = cappedBonusDice + (extraDiceNonBonus || 0) + stuntDice;
+    const totalPool = basePool + totalExtraDice;
+    const totalExtraSuccess = (extraSuccessBonus || 0) + (extraSuccessNonBonus || 0);
+    let actionPhrase = `Roll ${totalPool}`;
     if (totalExtraSuccess > 0) {
-      const successText = totalExtraSuccess === 1 ? "success" : "successes"
-      actionPhrase += `, ${totalExtraSuccess} ${successText}`
+      const successText = totalExtraSuccess === 1 ? "success" : "successes";
+      actionPhrase += `, ${totalExtraSuccess} ${successText}`;
     }
-    actionPhrase += `, TN ${targetNumber}`
+    actionPhrase += `, TN ${targetNumber}`;
     if (doublesThreshold < 10) {
-      actionPhrase += ` Double ${doublesThreshold}s`
+      actionPhrase += ` Double ${doublesThreshold}s`;
     } else {
-      actionPhrase += ` Double 10s`
+      actionPhrase += ` Double 10s`;
     }
-
     return {
       basePool,
       extraDice: totalExtraDice,
       totalPool,
       cappedBonusDice,
       actionPhrase,
-    }
-  }, [currentCharacter])
+    };
+  };
 
-  // Equipment management - moved to EquipmentTab component
+  const calculateSoak = () => {
+    if (!currentCharacter?.abilities?.physique) return 1;
+    const physique = calculateStatTotal(currentCharacter.abilities.physique);
+    let base = 1;
+    if (physique >= 3) base += 1;
+    const armorSoak = (currentCharacter?.armor || []).reduce(
+      (total: number, armor: ArmorPiece) =>
+        total + (Number.parseInt(String(armor.soak)) || 0),
+      0,
+    );
+    const modifier = currentCharacter?.staticValues?.soakModifier || 0;
+    return Math.max(0, base + armorSoak + Math.max(-5, Math.min(5, modifier)));
+  };
 
-  // Powers management - moved to PowersTab component
+  const calculateHardness = () => {
+    const essence = currentCharacter?.essence?.rating || 1;
+    const base = essence + 2;
+    const armorHardness = (currentCharacter?.armor || []).reduce(
+      (total: number, armor: ArmorPiece) =>
+        total + (Number.parseInt(String(armor.hardness)) || 0),
+      0,
+    );
+    const modifier = currentCharacter?.staticValues?.hardnessModifier || 0;
+    return Math.max(0, base + armorHardness + Math.max(-5, Math.min(5, modifier)));
+  };
 
-  // Social management - moved to SocialTab component
-
-  // Advancement management - moved to AdvancementTab component
-
-  // Rulings management - moved to RulingsTab component
-
-  // Import/Export functions
-  const exportCharacter = (character: Character) => {
+  const handleExport = async (character: Character) => {
     try {
-      const dataStr = JSON.stringify(character, null, 2)
-      const dataBlob = new Blob([dataStr], { type: "application/json" })
-
-      const link = document.createElement("a")
-      const url = window.URL.createObjectURL(dataBlob)
-      link.href = url
-      link.download = `${character.name.replace(/[^a-z0-9]/gi, "_").toLowerCase()}_exalted_character.json`
-      link.style.display = "none"
-      document.body.appendChild(link)
-      link.click()
-
-      setTimeout(() => {
-        document.body.removeChild(link)
-        window.URL.revokeObjectURL(url)
-      }, 100)
-    } catch (error) {
-      toast.error("Failed to export character. Please try again.")
+      await exportCharacter(character);
+    } catch {
+      toast.error("Failed to export character. Please try again.");
     }
-  }
+  };
 
-  const importCharacter = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
-
-    const reader = new FileReader()
-    reader.onload = e => {
-      try {
-        const importedData = JSON.parse(e.target?.result as string)
-
-        const isArray = Array.isArray(importedData)
-        const charactersToImport = isArray ? importedData : [importedData]
-
-        const validatedCharacters = charactersToImport.map((char: Partial<Character>) => {
-          if (!char.name) {
-            throw new Error("Invalid character data: missing name")
-          }
-
-          return {
-            ...createNewCharacter(char.name),
-            ...char,
-            id: uuidv4(),
-          }
-        })
-
-        // Add characters to store
-        loadCharacters([...characters, ...validatedCharacters])
-
-        if (validatedCharacters.length === 1) {
-          setCurrentCharacter(validatedCharacters[0].id)
-          setShowCharacterSelect(false)
-        }
-
-        event.target.value = ""
-
-        toast.success(`Successfully imported ${validatedCharacters.length} character(s)`)
-      } catch (error) {
-        toast.error(
-          "Failed to import character(s). Please ensure the file is a valid character export."
-        )
-        event.target.value = ""
+  const handleImport = async (file: File) => {
+    try {
+      const imported = await importCharacters(file);
+      loadCharacters([...characters, ...imported]);
+      if (imported.length === 1) {
+        selectCharacter(imported[0].id);
       }
+      toast.success(`Successfully imported ${imported.length} character(s)`);
+    } catch {
+      toast.error(
+        "Failed to import character(s). Please ensure the file is a valid character export.",
+      );
     }
-
-    reader.readAsText(file)
-  }
+  };
 
   if (showCharacterSelect || !currentCharacter) {
     return (
@@ -307,173 +160,59 @@ const ExaltedCharacterManager = () => {
         onCreateCharacter={createCharacter}
         onSelectCharacter={selectCharacter}
         onDeleteCharacter={deleteCharacter}
-        onExportCharacter={exportCharacter}
-        importCharacter={importCharacter}
+        onExportCharacter={handleExport}
+        importCharacter={async e => {
+          const file = e.target.files?.[0];
+          if (file) await handleImport(file);
+          e.target.value = "";
+        }}
         isSaving={isSaving}
         lastSaved={lastSaved}
         fileInputRef={fileInputRef}
       />
-    )
+    );
   }
-
-  const tabs = [
-    { id: "core", label: "Core Stats", icon: User },
-    { id: "combat", label: "Combat", icon: Swords },
-    { id: "equipment", label: "Equipment", icon: Shield },
-    { id: "powers", label: "Powers", icon: BookOpen },
-    { id: "socials", label: "Socials", icon: Users },
-    { id: "advancement", label: "Advancement", icon: TrendingUp },
-    { id: "rulings", label: "Rulings", icon: Scroll },
-  ]
 
   return (
     <div className="min-h-screen flex flex-col">
-      {/* Header */}
       <header className="bg-white border-b border-gray-200 px-6 py-4">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <h1 className="text-xl font-bold text-gray-800">Exalted: Essence Character Manager</h1>
           <div className="text-sm text-gray-600">
-            {!showCharacterSelect && currentCharacter && (
-              <span>
-                Managing: <strong>{currentCharacter.name}</strong>
-              </span>
-            )}
+            <span>
+              Managing: <strong>{currentCharacter.name}</strong>
+            </span>
           </div>
         </div>
       </header>
-
-      {/* Main Content */}
       <main className="flex-1">
         <div className="max-w-7xl mx-auto p-6 space-y-6">
-          {/* Header */}
-          <Card>
-            <CardContent className="flex items-center justify-between p-6">
-              <div className="flex items-center gap-4">
-                <h1 className="text-2xl font-bold">{currentCharacter.name}</h1>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="flex items-center gap-2 text-sm text-gray-600 cursor-help">
-                        {isSaving ? (
-                          <>
-                            <RefreshCw className="w-4 h-4 animate-spin" />
-                            Saving...
-                          </>
-                        ) : lastSaved ? (
-                          <>
-                            <Save className="w-4 h-4" />
-                            Saved {lastSaved.toLocaleTimeString()}
-                          </>
-                        ) : null}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        Characters are automatically saved to your browser&apos;s local storage
-                        every 10 minutes
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => exportCharacter(currentCharacter)}
-                >
-                  <Download className="w-4 h-4 mr-1" />
-                  Export
-                </Button>
-
-                <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
-                  <Upload className="w-4 h-4 mr-1" />
-                  Import
-                </Button>
-
-                <Button variant="outline" size="sm" onClick={() => setShowCharacterSelect(true)}>
-                  <User className="w-4 h-4 mr-1" />
-                  Switch
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Hidden file input */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".json"
-            onChange={importCharacter}
-            className="hidden"
+          <CharacterToolbar
+            character={currentCharacter}
+            isSaving={isSaving}
+            lastSaved={lastSaved}
+            onExport={handleExport}
+            onImport={handleImport}
+            onSwitch={() => setShowCharacterSelect(true)}
           />
-
-          {/* Main tabs */}
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="grid w-full grid-cols-4 lg:grid-cols-8">
-              {tabs.map(tab => {
-                const Icon = tab.icon
-                return (
-                  <TabsTrigger key={tab.id} value={tab.id} className="flex items-center gap-1">
-                    <Icon className="w-4 h-4" />
-                    <span className="hidden sm:inline">{tab.label}</span>
-                  </TabsTrigger>
-                )
-              })}
-            </TabsList>
-
-            <TabsContent value="core" className="space-y-6">
-              <CoreStatsTab
-                character={currentCharacter}
-                updateCharacter={updateCharacter}
-                calculateAbilityTotal={calculateAbilityTotal}
-                calculateDicePool={calculateDicePool}
-                globalAbilityAttribute={globalAbilityAttribute}
-                setGlobalAbilityAttribute={setGlobalAbilityAttribute}
-              />
-            </TabsContent>
-
-            <TabsContent value="combat" className="space-y-6">
-              <CombatTab
-                character={currentCharacter}
-                updateCharacter={updateCharacter}
-                calculations={calculations}
-                calculateSoak={calculateSoak}
-                calculateHardness={calculateHardness}
-              />
-            </TabsContent>
-
-            <TabsContent value="equipment" className="space-y-6">
-              <EquipmentTab character={currentCharacter} updateCharacter={updateCharacter} />
-            </TabsContent>
-
-            <TabsContent value="powers" className="space-y-6">
-              <PowersTab character={currentCharacter} updateCharacter={updateCharacter} />
-            </TabsContent>
-
-            <TabsContent value="socials" className="space-y-6">
-              <SocialTab
-                character={currentCharacter}
-                updateCharacter={updateCharacter}
-                calculateResolve={calculateResolve}
-              />
-            </TabsContent>
-
-            <TabsContent value="advancement" className="space-y-6">
-              <AdvancementTab character={currentCharacter} updateCharacter={updateCharacter} />
-            </TabsContent>
-
-            <TabsContent value="rulings" className="space-y-6">
-              <RulingsTab character={currentCharacter} updateCharacter={updateCharacter} />
-            </TabsContent>
-          </Tabs>
+          <CharacterTabs
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            character={currentCharacter}
+            updateCharacter={updateCharacter}
+            calculations={calculations}
+            calculateSoak={calculateSoak}
+            calculateHardness={calculateHardness}
+            calculateAbilityTotal={calculateAbilityTotal}
+            calculateDicePool={calculateDicePool}
+            globalAbilityAttribute={globalAbilityAttribute}
+            setGlobalAbilityAttribute={setGlobalAbilityAttribute}
+            resolve={calculations.resolve}
+          />
         </div>
       </main>
-
     </div>
-  )
-}
+  );
+};
 
-export default ExaltedCharacterManager
+export default ExaltedCharacterManager;

--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -26,7 +26,7 @@ import { v4 as uuidv4 } from "uuid"
 interface SocialTabProps {
   character: Character | null
   updateCharacter: (updates: Partial<Character>) => void
-  calculateResolve: () => number
+  resolve: number
 }
 
 const virtueOptions: Array<NonNullable<VirtueType>> = [
@@ -40,7 +40,7 @@ const virtueOptions: Array<NonNullable<VirtueType>> = [
 ]
 
 export const SocialTab: React.FC<SocialTabProps> = React.memo(
-  ({ character, updateCharacter, calculateResolve }) => {
+  ({ character, updateCharacter, resolve }) => {
     // Virtue management functions
     const setVirtue = useCallback(
       (type: "major" | "minor", virtue: VirtueType) => {
@@ -206,7 +206,7 @@ export const SocialTab: React.FC<SocialTabProps> = React.memo(
           <CardContent>
             <div className="space-y-2">
               <div className="text-center">
-                <div className="text-2xl font-bold text-blue-600">{calculateResolve()}</div>
+                <div className="text-2xl font-bold text-blue-600">{resolve}</div>
                 <div className="text-sm font-medium text-gray-700">Resolve</div>
               </div>
               <div className="text-xs text-gray-500 text-center">

--- a/hooks/useCharacterManagement.ts
+++ b/hooks/useCharacterManagement.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback } from "react";
+import { useCharacterStore } from "@/hooks/useCharacterStore";
+import type { Character } from "@/lib/character-types";
+
+export function useCharacterManagement() {
+  const {
+    characters,
+    currentCharacter,
+    addCharacter,
+    updateCurrentCharacter,
+    deleteCharacter,
+    setCurrentCharacter,
+    loadCharacters,
+  } = useCharacterStore();
+
+  const [showCharacterSelect, setShowCharacterSelect] = useState(true);
+
+  const createCharacter = useCallback(
+    (name: string) => {
+      if (!name.trim()) return;
+      addCharacter(name.trim());
+      setShowCharacterSelect(false);
+    },
+    [addCharacter],
+  );
+
+  const selectCharacter = useCallback(
+    (id: string) => {
+      setCurrentCharacter(id);
+      setShowCharacterSelect(false);
+    },
+    [setCurrentCharacter],
+  );
+
+  const updateCharacter = useCallback(
+    (updates: Partial<Character>) => {
+      updateCurrentCharacter(updates);
+    },
+    [updateCurrentCharacter],
+  );
+
+  return {
+    characters,
+    currentCharacter,
+    showCharacterSelect,
+    setShowCharacterSelect,
+    createCharacter,
+    selectCharacter,
+    updateCharacter,
+    deleteCharacter,
+    loadCharacters,
+  };
+}

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -1,0 +1,54 @@
+import type { Character } from "@/lib/character-types";
+import { createNewCharacter } from "@/lib/character-defaults";
+import { v4 as uuidv4 } from "uuid";
+
+export async function exportCharacter(character: Character): Promise<void> {
+  const dataStr = JSON.stringify(character, null, 2);
+  const dataBlob = new Blob([dataStr], { type: "application/json" });
+  const link = document.createElement("a");
+  const url = window.URL.createObjectURL(dataBlob);
+  link.href = url;
+  link.download = `${character.name
+    .replace(/[^a-z0-9]/gi, "_")
+    .toLowerCase()}_exalted_character.json`;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  setTimeout(() => {
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  }, 100);
+}
+
+export async function exportCharacters(
+  characters: Character[],
+  filename = "all_exalted_characters.json",
+): Promise<void> {
+  const dataStr = JSON.stringify(characters, null, 2);
+  const dataBlob = new Blob([dataStr], { type: "application/json" });
+  const link = document.createElement("a");
+  const url = window.URL.createObjectURL(dataBlob);
+  link.href = url;
+  link.download = filename;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  setTimeout(() => {
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  }, 100);
+}
+
+export async function importCharacters(file: File): Promise<Character[]> {
+  const text = await file.text();
+  const importedData = JSON.parse(text);
+  const charactersToImport = Array.isArray(importedData)
+    ? importedData
+    : [importedData];
+
+  return charactersToImport.map((char: Partial<Character>) => ({
+    ...createNewCharacter(char.name ?? "Unnamed"),
+    ...char,
+    id: uuidv4(),
+  }));
+}


### PR DESCRIPTION
## Summary
- break ExaltedCharacterManager into CharacterToolbar and CharacterTabs
- add useCharacterManagement hook for CRUD logic
- move character import/export to lib/character-storage

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68963048939c83329d2a4d9026123f37