### PR TITLE
Refactor essence editing into reusable component

### DIFF
--- a/components/EssenceEditor.stories.tsx
+++ b/components/EssenceEditor.stories.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from "react"
+import { EssenceEditor } from "./EssenceEditor"
+import type { Essence } from "@/lib/character-types"
+
+const meta = { title: "Components/EssenceEditor", component: EssenceEditor }
+export default meta
+
+export const Basic = () => {
+  const [essence, setEssence] = useState<Essence>({
+    rating: 1,
+    motes: 5,
+    commitments: 0,
+    spent: 0,
+    anima: 0,
+  })
+
+  return <EssenceEditor essence={essence} onChange={setEssence} />
+}

--- a/components/EssenceEditor.tsx
+++ b/components/EssenceEditor.tsx
@@ -1,0 +1,101 @@
+import React from "react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import type { Essence } from "@/lib/character-types"
+
+interface EssenceEditorProps {
+  essence: Essence
+  onChange: (essence: Essence) => void
+}
+
+export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(
+  ({ essence, onChange }) => {
+    const update = (field: keyof Essence, value: number) => {
+      onChange({ ...essence, [field]: value })
+    }
+
+    const rating = essence.rating ?? 1
+    const motes = essence.motes ?? 5
+    const commitments = essence.commitments ?? 0
+    const spent = essence.spent ?? 0
+
+    const remain = motes - commitments - spent
+    const open = motes - commitments
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Label>Rating</Label>
+          <Input
+            type="number"
+            value={rating}
+            onChange={e => {
+              const value = Math.max(0, Math.min(10, Number.parseInt(e.target.value) || 0))
+              update("rating", value)
+            }}
+            className="w-20 text-center"
+            min={0}
+            max={10}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label>Motes</Label>
+          <Input
+            type="number"
+            value={motes}
+            onChange={e => {
+              const value = Math.max(0, Math.min(50, Number.parseInt(e.target.value) || 0))
+              update("motes", value)
+            }}
+            className="w-20 text-center"
+            min={0}
+            max={50}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label>Commitments</Label>
+          <Input
+            type="number"
+            value={commitments}
+            onChange={e => {
+              const value = Math.max(0, Number.parseInt(e.target.value) || 0)
+              update("commitments", value)
+            }}
+            className="w-20 text-center"
+            min={0}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label>Spent</Label>
+          <Input
+            type="number"
+            value={spent}
+            onChange={e => {
+              const value = Math.max(0, Number.parseInt(e.target.value) || 0)
+              update("spent", value)
+            }}
+            className="w-20 text-center"
+            min={0}
+          />
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label className="font-medium text-blue-600">Remain</Label>
+            <span className="font-bold text-blue-600">{remain}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <Label className="font-medium text-green-600">Open</Label>
+            <span className="font-bold text-green-600">{open}</span>
+          </div>
+        </div>
+      </div>
+    )
+  },
+)
+
+EssenceEditor.displayName = "EssenceEditor"
+
+export default EssenceEditor
+

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -6,8 +6,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
+import { EssenceEditor } from "@/components/EssenceEditor"
 import type { Character } from "@/lib/character-types"
 import { getAnimaLevel, getActiveAnimaRulings, calculateStatTotal } from "@/lib/exalted-utils"
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations"
@@ -54,87 +54,18 @@ export const CombatTab: React.FC<CombatTabProps> = React.memo(
           </CardHeader>
           <CardContent>
             <div className="grid md:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <Label>Rating</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.rating || 1}
-                    onChange={e => {
-                      const value = Math.max(0, Math.min(10, Number.parseInt(e.target.value) || 0))
-                      updateCharacter({
-                        essence: { ...character.essence, rating: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                    max={10}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Motes</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.motes || 5}
-                    onChange={e => {
-                      const value = Math.max(0, Math.min(50, Number.parseInt(e.target.value) || 0))
-                      updateCharacter({
-                        essence: { ...character.essence, motes: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                    max={50}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Commitments</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.commitments || 0}
-                    onChange={e => {
-                      const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                      updateCharacter({
-                        essence: { ...character.essence, commitments: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Spent</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.spent || 0}
-                    onChange={e => {
-                      const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                      updateCharacter({
-                        essence: { ...character.essence, spent: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                  />
-                </div>
-                <Separator />
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <Label className="font-medium text-blue-600">Remain</Label>
-                    <span className="font-bold text-blue-600">
-                      {(character.essence?.motes || 5) -
-                        (character.essence?.commitments || 0) -
-                        (character.essence?.spent || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Label className="font-medium text-green-600">Open</Label>
-                    <span className="font-bold text-green-600">
-                      {(character.essence?.motes || 5) - (character.essence?.commitments || 0)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              <EssenceEditor
+                essence={
+                  character.essence || {
+                    rating: 1,
+                    motes: 5,
+                    commitments: 0,
+                    spent: 0,
+                    anima: 0,
+                  }
+                }
+                onChange={essence => updateCharacter({ essence })}
+              />
 
               <div className="space-y-4">
                 {/* Anima Slider */}

--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { EssenceEditor } from "@/components/EssenceEditor"
 import {
   Select,
   SelectContent,
@@ -13,7 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
 import type {
   Character,
   StatBlock,
@@ -67,87 +67,18 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
           </CardHeader>
           <CardContent>
             <div className="grid md:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <Label>Rating</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.rating || 1}
-                    onChange={e => {
-                      const value = Math.max(0, Math.min(10, Number.parseInt(e.target.value) || 0))
-                      updateCharacter({
-                        essence: { ...character.essence, rating: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                    max={10}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Motes</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.motes || 5}
-                    onChange={e => {
-                      const value = Math.max(0, Math.min(50, Number.parseInt(e.target.value) || 0))
-                      updateCharacter({
-                        essence: { ...character.essence, motes: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                    max={50}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Commitments</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.commitments || 0}
-                    onChange={e => {
-                      const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                      updateCharacter({
-                        essence: { ...character.essence, commitments: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label>Spent</Label>
-                  <Input
-                    type="number"
-                    value={character.essence?.spent || 0}
-                    onChange={e => {
-                      const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                      updateCharacter({
-                        essence: { ...character.essence, spent: value },
-                      })
-                    }}
-                    className="w-20 text-center"
-                    min={0}
-                  />
-                </div>
-                <Separator />
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <Label className="font-medium text-blue-600">Remain</Label>
-                    <span className="font-bold text-blue-600">
-                      {(character.essence?.motes || 5) -
-                        (character.essence?.commitments || 0) -
-                        (character.essence?.spent || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Label className="font-medium text-green-600">Open</Label>
-                    <span className="font-bold text-green-600">
-                      {(character.essence?.motes || 5) - (character.essence?.commitments || 0)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              <EssenceEditor
+                essence={
+                  character.essence || {
+                    rating: 1,
+                    motes: 5,
+                    commitments: 0,
+                    spent: 0,
+                    anima: 0,
+                  }
+                }
+                onChange={essence => updateCharacter({ essence })}
+              />
 
               <div className="space-y-4">
                 {/* Anima Slider */}


### PR DESCRIPTION
## Summary
- add `EssenceEditor` component for essence fields and calculations
- reuse `EssenceEditor` in core stats and combat tabs to remove duplication
- document component with simple Storybook example

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6896339749048332b9fc6abc5c6015ab