### PR TITLE
Refactor stats tables and dice pool editor

### DIFF
--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -1,40 +1,30 @@
 // Core Stats Tab Component - Essence, attributes, abilities, and dice pool calculator
 
-import React, { useCallback, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { EssenceEditor } from "@/components/EssenceEditor"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
-import type {
-  Character,
-  StatBlock,
-  AttributeType,
-  AbilityType,
-} from "@/lib/character-types"
-import { getAnimaLevel, getActiveAnimaRulings, calculateStatTotal } from "@/lib/exalted-utils"
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { EssenceEditor } from "@/components/EssenceEditor";
+import { Badge } from "@/components/ui/badge";
+import type { Character, AttributeType, AbilityType } from "@/lib/character-types";
+import { getAnimaLevel, getActiveAnimaRulings, calculateStatTotal } from "@/lib/exalted-utils";
+import { StatTable } from "@/components/forms/StatTable";
+import { attributeConfig, abilityConfig } from "@/lib/stat-config";
+import { DicePoolEditor } from "@/components/forms/DicePoolEditor";
 
 interface CoreStatsTabProps {
-  character: Character | null
-  updateCharacter: (updates: Partial<Character>) => void
-  calculateAbilityTotal: (abilityKey: AbilityType) => number
+  character: Character | null;
+  updateCharacter: (updates: Partial<Character>) => void;
+  calculateAbilityTotal: (abilityKey: AbilityType) => number;
   calculateDicePool: () => {
-    basePool: number
-    extraDice: number
-    totalPool: number
-    cappedBonusDice: number
-    actionPhrase: string
-  }
-  globalAbilityAttribute: AttributeType | "none"
-  setGlobalAbilityAttribute: (attribute: AttributeType | "none") => void
+    basePool: number;
+    extraDice: number;
+    totalPool: number;
+    cappedBonusDice: number;
+    actionPhrase: string;
+  };
+  globalAbilityAttribute: AttributeType | "none";
+  setGlobalAbilityAttribute: (attribute: AttributeType | "none") => void;
 }
 
 export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
@@ -55,8 +45,17 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
             </CardContent>
           </Card>
         </div>
-      )
+      );
     }
+
+    const abilityTotalColor =
+      globalAbilityAttribute === "fortitude"
+        ? "text-green-600"
+        : globalAbilityAttribute === "finesse"
+          ? "text-blue-600"
+          : globalAbilityAttribute === "force"
+            ? "text-red-600"
+            : "text-gray-700";
 
     return (
       <div className="space-y-6">
@@ -98,10 +97,10 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                       step="1"
                       value={character.essence?.anima || 0}
                       onChange={e => {
-                        const value = Number.parseInt(e.target.value)
+                        const value = Number.parseInt(e.target.value);
                         updateCharacter({
                           essence: { ...character.essence, anima: value },
-                        })
+                        });
                       }}
                       className={`w-full h-3 rounded-lg appearance-none cursor-pointer slider ${
                         (character?.essence?.anima || 0) <= 4
@@ -113,7 +112,7 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                               : "slider-iconic"
                       }`}
                       style={{
-                        background: `linear-gradient(to right, 
+                        background: `linear-gradient(to right,
                         ${
                           (character?.essence?.anima || 0) <= 4
                             ? "#9ca3af"
@@ -122,7 +121,7 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                               : (character?.essence?.anima || 0) <= 9
                                 ? "#ef4444"
                                 : "#9333ea"
-                        } 0%, 
+                        } 0%,
                         ${
                           (character?.essence?.anima || 0) <= 4
                             ? "#9ca3af"
@@ -131,8 +130,8 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                               : (character?.essence?.anima || 0) <= 9
                                 ? "#ef4444"
                                 : "#9333ea"
-                        } ${((character?.essence?.anima || 0) / 10) * 100}%, 
-                        #e5e7eb ${((character?.essence?.anima || 0) / 10) * 100}%, 
+                        } ${((character?.essence?.anima || 0) / 10) * 100}%,
+                        #e5e7eb ${((character?.essence?.anima || 0) / 10) * 100}%,
                         #e5e7eb 100%)`,
                       }}
                     />
@@ -169,7 +168,7 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
                           <div key={index} className="text-sm text-purple-600">
                             • {ruling}
                           </div>
-                        )
+                        ),
                       )}
                     </div>
                   )}
@@ -198,104 +197,17 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
               <CardTitle>Attributes</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="bg-gray-100">
-                      <th className="py-2 px-3 text-left">Attribute</th>
-                      <th className="py-2 px-3 text-center">Base</th>
-                      <th className="py-2 px-3 text-center">Added</th>
-                      <th className="py-2 px-3 text-center">Bonus</th>
-                      <th className="py-2 px-3 text-center">Total</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.entries(character.attributes || {}).map(
-                      ([key, attr]: [AttributeType, StatBlock]) => {
-                        const colorClass =
-                          key === "fortitude"
-                            ? "text-green-600"
-                            : key === "finesse"
-                              ? "text-blue-600"
-                              : key === "force"
-                                ? "text-red-600"
-                                : "text-gray-700"
-                        return (
-                          <tr key={key} className="border-b border-gray-200">
-                            <td className={`py-2 px-3 font-medium capitalize ${colorClass}`}>
-                              {key}
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.base}
-                                onChange={e => {
-                                  const value = Math.max(
-                                    1,
-                                    Math.min(5, Number.parseInt(e.target.value) || 1)
-                                  )
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, base: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={1}
-                                max={5}
-                              />
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.added}
-                                onChange={e => {
-                                  const maxAdded = Math.max(0, 5 - attr.base)
-                                  const value = Math.min(
-                                    maxAdded,
-                                    Math.max(0, Number.parseInt(e.target.value) || 0)
-                                  )
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, added: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={0}
-                                max={Math.max(0, 5 - attr.base)}
-                              />
-                            </td>
-                            <td className="py-2 px-3">
-                              <Input
-                                type="number"
-                                value={attr.bonus}
-                                onChange={e => {
-                                  const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                                  updateCharacter({
-                                    attributes: {
-                                      ...character.attributes,
-                                      [key]: { ...attr, bonus: value },
-                                    },
-                                  })
-                                }}
-                                className="w-16 text-center"
-                                min={0}
-                              />
-                            </td>
-                            <td className={`py-2 px-3 font-bold text-center ${colorClass}`}>
-                              {calculateStatTotal(attr)}
-                            </td>
-                          </tr>
-                        )
-                      }
-                    )}
-                  </tbody>
-                </table>
-              </div>
-              <div className="mt-2 text-xs text-gray-400 italic">Base + Added cannot exceed 5</div>
+              <StatTable
+                config={attributeConfig}
+                stats={character.attributes}
+                onChange={(key, stat) =>
+                  updateCharacter({
+                    attributes: { ...character.attributes, [key]: stat },
+                  })
+                }
+                getTotal={key => calculateStatTotal(character.attributes[key])}
+                minBase={1}
+              />
             </CardContent>
           </Card>
 
@@ -354,440 +266,34 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="max-h-96 overflow-y-auto">
-                <table className="w-full">
-                  <thead className="sticky top-0 bg-gray-100">
-                    <tr>
-                      <th className="py-2 px-3 text-left text-sm">Ability</th>
-                      <th className="py-2 px-3 text-center text-sm">Base</th>
-                      <th className="py-2 px-3 text-center text-sm">Added</th>
-                      <th className="py-2 px-3 text-center text-sm">Bonus</th>
-                      <th className="py-2 px-3 text-center text-sm">Total</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.entries(character.abilities || {}).map(
-                      ([key, ability]: [AbilityType, StatBlock]) => (
-                        <tr key={key} className="border-b border-gray-200">
-                          <td className="py-2 px-3 font-medium text-gray-700 text-sm capitalize">
-                            {key.replace(/([A-Z])/g, " $1").trim()}
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.base}
-                              onChange={e => {
-                                const value = Math.max(
-                                  0,
-                                  Math.min(5, Number.parseInt(e.target.value) || 0)
-                                )
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, base: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                              max={5}
-                            />
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.added}
-                              onChange={e => {
-                                const maxAdded = Math.max(0, 5 - ability.base)
-                                const value = Math.min(
-                                  maxAdded,
-                                  Math.max(0, Number.parseInt(e.target.value) || 0)
-                                )
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, added: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                              max={Math.max(0, 5 - ability.base)}
-                            />
-                          </td>
-                          <td className="py-2 px-3">
-                            <Input
-                              type="number"
-                              value={ability.bonus}
-                              onChange={e => {
-                                const value = Math.max(0, Number.parseInt(e.target.value) || 0)
-                                updateCharacter({
-                                  abilities: {
-                                    ...character.abilities,
-                                    [key]: { ...ability, bonus: value },
-                                  },
-                                })
-                              }}
-                              className="w-16 text-center text-sm"
-                              min={0}
-                            />
-                          </td>
-                          <td
-                            className={`py-2 px-3 font-bold text-center text-sm ${
-                              globalAbilityAttribute === "fortitude"
-                                ? "text-green-600"
-                                : globalAbilityAttribute === "finesse"
-                                  ? "text-blue-600"
-                                  : globalAbilityAttribute === "force"
-                                    ? "text-red-600"
-                                    : "text-gray-700"
-                            }`}
-                          >
-                            {calculateAbilityTotal(key)}
-                          </td>
-                        </tr>
-                      )
-                    )}
-                  </tbody>
-                </table>
-              </div>
-              <div className="mt-2 text-xs text-gray-400 italic">Base + Added cannot exceed 5</div>
+              <StatTable
+                config={abilityConfig}
+                stats={character.abilities}
+                onChange={(key, stat) =>
+                  updateCharacter({
+                    abilities: { ...character.abilities, [key]: stat },
+                  })
+                }
+                getTotal={calculateAbilityTotal}
+                minBase={0}
+                scrollable
+                totalColorClass={abilityTotalColor}
+              />
             </CardContent>
           </Card>
         </div>
 
         {/* Roll Assembler */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Roll Assembler</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-6">
-              {/* Pool Assembly */}
-              <div>
-                <h3 className="font-semibold text-gray-700 mb-3">Pool Assembly</h3>
-                <div className="space-y-3">
-                  <div>
-                    <Label className="block text-sm font-medium text-gray-600 mb-1">
-                      Attribute
-                    </Label>
-                    <div className="flex gap-2">
-                      <Button
-                        variant={
-                          character?.dicePool?.attribute === "fortitude" ? "default" : "outline"
-                        }
-                        size="sm"
-                        onClick={() =>
-                          updateCharacter({
-                            dicePool: { ...character.dicePool, attribute: "fortitude" },
-                          })
-                        }
-                        className={
-                          character?.dicePool?.attribute === "fortitude"
-                            ? "bg-green-600 hover:bg-green-700"
-                            : "text-green-600 border-green-600 hover:bg-green-50"
-                        }
-                      >
-                        <div>Fortitude</div>
-                        <div className="text-xs opacity-75">
-                          (
-                          {calculateStatTotal(
-                            character?.attributes?.fortitude || { base: 0, added: 0, bonus: 0 }
-                          )}
-                          )
-                        </div>
-                      </Button>
-                      <Button
-                        variant={
-                          character?.dicePool?.attribute === "finesse" ? "default" : "outline"
-                        }
-                        size="sm"
-                        onClick={() =>
-                          updateCharacter({
-                            dicePool: { ...character.dicePool, attribute: "finesse" },
-                          })
-                        }
-                        className={
-                          character?.dicePool?.attribute === "finesse"
-                            ? "bg-blue-600 hover:bg-blue-700"
-                            : "text-blue-600 border-blue-600 hover:bg-blue-50"
-                        }
-                      >
-                        <div>Finesse</div>
-                        <div className="text-xs opacity-75">
-                          (
-                          {calculateStatTotal(
-                            character?.attributes?.finesse || { base: 0, added: 0, bonus: 0 }
-                          )}
-                          )
-                        </div>
-                      </Button>
-                      <Button
-                        variant={character?.dicePool?.attribute === "force" ? "default" : "outline"}
-                        size="sm"
-                        onClick={() =>
-                          updateCharacter({
-                            dicePool: { ...character.dicePool, attribute: "force" },
-                          })
-                        }
-                        className={
-                          character?.dicePool?.attribute === "force"
-                            ? "bg-red-600 hover:bg-red-700"
-                            : "text-red-600 border-red-600 hover:bg-red-50"
-                        }
-                      >
-                        <div>Force</div>
-                        <div className="text-xs opacity-75">
-                          (
-                          {calculateStatTotal(
-                            character?.attributes?.force || { base: 0, added: 0, bonus: 0 }
-                          )}
-                          )
-                        </div>
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div>
-                    <Label className="block text-sm font-medium text-gray-600 mb-1">Ability</Label>
-                    <Select
-                      value={character?.dicePool?.ability || "athletics"}
-                      onValueChange={value =>
-                        updateCharacter({
-                          dicePool: {
-                            ...character.dicePool,
-                            ability: value as keyof typeof character.abilities,
-                          },
-                        })
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Object.keys(character?.abilities || {}).map(ability => (
-                          <SelectItem key={ability} value={ability}>
-                            {ability.charAt(0).toUpperCase() +
-                              ability.slice(1).replace(/([A-Z])/g, " $1")}{" "}
-                            (
-                            {calculateStatTotal(
-                              character?.abilities?.[ability] || { base: 0, added: 0, bonus: 0 }
-                            )}
-                            )
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Target Number
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.targetNumber || 7}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              targetNumber: Number.parseInt(e.target.value) || 7,
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={1}
-                        max={10}
-                      />
-                    </div>
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Doubles Threshold
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.doublesThreshold || 10}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              doublesThreshold: Number.parseInt(e.target.value) || 10,
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={1}
-                        max={10}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Extra Dice and Success */}
-              <div>
-                <h3 className="font-semibold text-gray-700 mb-3">Modifiers</h3>
-                <div className="space-y-3">
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Extra Dice (Bonus)
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.extraDiceBonus || 0}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              extraDiceBonus: Math.min(
-                                10,
-                                Math.max(0, Number.parseInt(e.target.value) || 0)
-                              ),
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={0}
-                        max={10}
-                      />
-                      <div className="text-xs text-gray-500 mt-1">Max: 10</div>
-                    </div>
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Extra Dice (Non-Bonus)
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.extraDiceNonBonus || 0}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              extraDiceNonBonus: Math.max(0, Number.parseInt(e.target.value) || 0),
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={0}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Extra Success (Bonus)
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.extraSuccessBonus || 0}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              extraSuccessBonus: Math.min(
-                                5,
-                                Math.max(0, Number.parseInt(e.target.value) || 0)
-                              ),
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={0}
-                        max={5}
-                      />
-                      <div className="text-xs text-gray-500 mt-1">Max: 5</div>
-                    </div>
-                    <div>
-                      <Label className="block text-sm font-medium text-gray-600 mb-1">
-                        Extra Success (Non-Bonus)
-                      </Label>
-                      <Input
-                        type="number"
-                        value={character?.dicePool?.extraSuccessNonBonus || 0}
-                        onChange={e =>
-                          updateCharacter({
-                            dicePool: {
-                              ...character.dicePool,
-                              extraSuccessNonBonus: Math.max(
-                                0,
-                                Number.parseInt(e.target.value) || 0
-                              ),
-                            },
-                          })
-                        }
-                        className="text-center"
-                        min={0}
-                      />
-                    </div>
-                  </div>
-
-                  {/* Stunt Checkbox */}
-                  <div className="mt-4 flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="stunt-checkbox"
-                      checked={character?.dicePool?.isStunted || false}
-                      onChange={e =>
-                        updateCharacter({
-                          dicePool: {
-                            ...character.dicePool,
-                            isStunted: e.target.checked,
-                          },
-                        })
-                      }
-                      className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
-                    />
-                    <Label htmlFor="stunt-checkbox" className="text-sm font-medium text-gray-700">
-                      Stunt (+2 dice, non-capped)
-                    </Label>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Results */}
-            <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-              <h3 className="font-semibold text-blue-800 mb-2">Dice Pool Summary</h3>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-3">
-                <div>
-                  <div className="text-blue-600 font-medium">Base Pool</div>
-                  <div className="text-lg font-bold text-blue-800">
-                    {calculateDicePool().basePool}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-blue-600 font-medium">Extra Dice</div>
-                  <div className="text-lg font-bold text-blue-800">
-                    +{calculateDicePool().extraDice}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-blue-600 font-medium">Total Dice</div>
-                  <div className="text-lg font-bold text-blue-800">
-                    {calculateDicePool().totalPool}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-blue-600 font-medium">Extra Success</div>
-                  <div className="text-lg font-bold text-blue-800">
-                    +
-                    {(character?.dicePool?.extraSuccessBonus || 0) +
-                      (character?.dicePool?.extraSuccessNonBonus || 0)}
-                  </div>
-                </div>
-              </div>
-              <div className="text-center p-2 bg-blue-100 rounded font-medium text-blue-800">
-                {calculateDicePool().actionPhrase}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <DicePoolEditor
+          character={character}
+          updateCharacter={updateCharacter}
+          calculateDicePool={calculateDicePool}
+        />
       </div>
-    )
-  }
-)
+    );
+  },
+);
 
-CoreStatsTab.displayName = "CoreStatsTab"
+CoreStatsTab.displayName = "CoreStatsTab";
+
+export default CoreStatsTab;

--- a/components/forms/DicePoolEditor.tsx
+++ b/components/forms/DicePoolEditor.tsx
@@ -1,0 +1,369 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Character } from "@/lib/character-types";
+import { calculateStatTotal } from "@/lib/exalted-utils";
+
+interface DicePoolEditorProps {
+  character: Character;
+  updateCharacter: (updates: Partial<Character>) => void;
+  calculateDicePool: () => {
+    basePool: number;
+    extraDice: number;
+    totalPool: number;
+    cappedBonusDice: number;
+    actionPhrase: string;
+  };
+}
+
+export const DicePoolEditor: React.FC<DicePoolEditorProps> = React.memo(
+  ({ character, updateCharacter, calculateDicePool }) => {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Roll Assembler</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid md:grid-cols-2 gap-6">
+            {/* Pool Assembly */}
+            <div>
+              <h3 className="font-semibold text-gray-700 mb-3">Pool Assembly</h3>
+              <div className="space-y-3">
+                <div>
+                  <Label className="block text-sm font-medium text-gray-600 mb-1">Attribute</Label>
+                  <div className="flex gap-2">
+                    <Button
+                      variant={
+                        character?.dicePool?.attribute === "fortitude" ? "default" : "outline"
+                      }
+                      size="sm"
+                      onClick={() =>
+                        updateCharacter({
+                          dicePool: { ...character.dicePool, attribute: "fortitude" },
+                        })
+                      }
+                      className={
+                        character?.dicePool?.attribute === "fortitude"
+                          ? "bg-green-600 hover:bg-green-700"
+                          : "text-green-600 border-green-600 hover:bg-green-50"
+                      }
+                    >
+                      <div>Fortitude</div>
+                      <div className="text-xs opacity-75">
+                        (
+                        {calculateStatTotal(
+                          character?.attributes?.fortitude || { base: 0, added: 0, bonus: 0 }
+                        )}
+                        )
+                      </div>
+                    </Button>
+                    <Button
+                      variant={
+                        character?.dicePool?.attribute === "finesse" ? "default" : "outline"
+                      }
+                      size="sm"
+                      onClick={() =>
+                        updateCharacter({
+                          dicePool: { ...character.dicePool, attribute: "finesse" },
+                        })
+                      }
+                      className={
+                        character?.dicePool?.attribute === "finesse"
+                          ? "bg-blue-600 hover:bg-blue-700"
+                          : "text-blue-600 border-blue-600 hover:bg-blue-50"
+                      }
+                    >
+                      <div>Finesse</div>
+                      <div className="text-xs opacity-75">
+                        (
+                        {calculateStatTotal(
+                          character?.attributes?.finesse || { base: 0, added: 0, bonus: 0 }
+                        )}
+                        )
+                      </div>
+                    </Button>
+                    <Button
+                      variant={
+                        character?.dicePool?.attribute === "force" ? "default" : "outline"
+                      }
+                      size="sm"
+                      onClick={() =>
+                        updateCharacter({
+                          dicePool: { ...character.dicePool, attribute: "force" },
+                        })
+                      }
+                      className={
+                        character?.dicePool?.attribute === "force"
+                          ? "bg-red-600 hover:bg-red-700"
+                          : "text-red-600 border-red-600 hover:bg-red-50"
+                      }
+                    >
+                      <div>Force</div>
+                      <div className="text-xs opacity-75">
+                        (
+                        {calculateStatTotal(
+                          character?.attributes?.force || { base: 0, added: 0, bonus: 0 }
+                        )}
+                        )
+                      </div>
+                    </Button>
+                  </div>
+                </div>
+
+                <div>
+                  <Label className="block text-sm font-medium text-gray-600 mb-1">Ability</Label>
+                  <Select
+                    value={character?.dicePool?.ability || "athletics"}
+                    onValueChange={value =>
+                      updateCharacter({
+                        dicePool: {
+                          ...character.dicePool,
+                          ability: value as keyof typeof character.abilities,
+                        },
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.keys(character?.abilities || {}).map(ability => (
+                        <SelectItem key={ability} value={ability}>
+                          {ability.charAt(0).toUpperCase() +
+                            ability.slice(1).replace(/([A-Z])/g, " $1")}{" "}
+                          (
+                          {calculateStatTotal(
+                            character?.abilities?.[ability as keyof typeof character.abilities] || {
+                              base: 0,
+                              added: 0,
+                              bonus: 0,
+                            },
+                          )}
+                          )
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Target Number
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.targetNumber || 7}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            targetNumber: Number.parseInt(e.target.value) || 7,
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={1}
+                      max={10}
+                    />
+                  </div>
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Doubles Threshold
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.doublesThreshold || 10}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            doublesThreshold: Number.parseInt(e.target.value) || 10,
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={1}
+                      max={10}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Extra Dice and Success */}
+            <div>
+              <h3 className="font-semibold text-gray-700 mb-3">Modifiers</h3>
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Extra Dice (Bonus)
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.extraDiceBonus || 0}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            extraDiceBonus: Math.min(
+                              10,
+                              Math.max(0, Number.parseInt(e.target.value) || 0),
+                            ),
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={0}
+                      max={10}
+                    />
+                    <div className="text-xs text-gray-500 mt-1">Max: 10</div>
+                  </div>
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Extra Dice (Non-Bonus)
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.extraDiceNonBonus || 0}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            extraDiceNonBonus: Math.max(0, Number.parseInt(e.target.value) || 0),
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={0}
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Extra Success (Bonus)
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.extraSuccessBonus || 0}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            extraSuccessBonus: Math.min(
+                              5,
+                              Math.max(0, Number.parseInt(e.target.value) || 0),
+                            ),
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={0}
+                      max={5}
+                    />
+                    <div className="text-xs text-gray-500 mt-1">Max: 5</div>
+                  </div>
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-600 mb-1">
+                      Extra Success (Non-Bonus)
+                    </Label>
+                    <Input
+                      type="number"
+                      value={character?.dicePool?.extraSuccessNonBonus || 0}
+                      onChange={e =>
+                        updateCharacter({
+                          dicePool: {
+                            ...character.dicePool,
+                            extraSuccessNonBonus: Math.max(
+                              0,
+                              Number.parseInt(e.target.value) || 0,
+                            ),
+                          },
+                        })
+                      }
+                      className="text-center"
+                      min={0}
+                    />
+                  </div>
+                </div>
+
+                {/* Stunt Checkbox */}
+                <div className="mt-4 flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="stunt-checkbox"
+                    checked={character?.dicePool?.isStunted || false}
+                    onChange={e =>
+                      updateCharacter({
+                        dicePool: {
+                          ...character.dicePool,
+                          isStunted: e.target.checked,
+                        },
+                      })
+                    }
+                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                  />
+                  <Label htmlFor="stunt-checkbox" className="text-sm font-medium text-gray-700">
+                    Stunt (+2 dice, non-capped)
+                  </Label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Results */}
+          <div className="mt-6 p-4 bg-blue-50 rounded-lg">
+            <h3 className="font-semibold text-blue-800 mb-2">Dice Pool Summary</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-3">
+              <div>
+                <div className="text-blue-600 font-medium">Base Pool</div>
+                <div className="text-lg font-bold text-blue-800">
+                  {calculateDicePool().basePool}
+                </div>
+              </div>
+              <div>
+                <div className="text-blue-600 font-medium">Extra Dice</div>
+                <div className="text-lg font-bold text-blue-800">
+                  +{calculateDicePool().extraDice}
+                </div>
+              </div>
+              <div>
+                <div className="text-blue-600 font-medium">Total Dice</div>
+                <div className="text-lg font-bold text-blue-800">
+                  {calculateDicePool().totalPool}
+                </div>
+              </div>
+              <div>
+                <div className="text-blue-600 font-medium">Extra Success</div>
+                <div className="text-lg font-bold text-blue-800">
+                  +
+                  {(character?.dicePool?.extraSuccessBonus || 0) +
+                    (character?.dicePool?.extraSuccessNonBonus || 0)}
+                </div>
+              </div>
+            </div>
+            <div className="text-center p-2 bg-blue-100 rounded font-medium text-blue-800">
+              {calculateDicePool().actionPhrase}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+DicePoolEditor.displayName = "DicePoolEditor";
+
+export default DicePoolEditor;

--- a/components/forms/StatTable.tsx
+++ b/components/forms/StatTable.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { type StatBlock } from "@/lib/character-types";
+import type { StatConfig } from "@/lib/stat-config";
+
+interface StatTableProps<T extends string> {
+  config: StatConfig<T>[];
+  stats: Record<T, StatBlock>;
+  onChange: (key: T, stat: StatBlock) => void;
+  getTotal: (key: T) => number;
+  minBase?: number;
+  totalColorClass?: string;
+  scrollable?: boolean;
+}
+
+export function StatTable<T extends string>({
+  config,
+  stats,
+  onChange,
+  getTotal,
+  minBase = 0,
+  totalColorClass,
+  scrollable = false,
+}: StatTableProps<T>) {
+  const wrapperClass = scrollable ? "max-h-96 overflow-y-auto" : "overflow-x-auto";
+  const theadClass = scrollable ? "sticky top-0 bg-gray-100" : "bg-gray-100";
+
+  return (
+    <div className={wrapperClass}>
+      <table className="w-full">
+        <thead className={theadClass}>
+          <tr>
+            <th className="py-2 px-3 text-left text-sm">Name</th>
+            <th className="py-2 px-3 text-center text-sm">Base</th>
+            <th className="py-2 px-3 text-center text-sm">Added</th>
+            <th className="py-2 px-3 text-center text-sm">Bonus</th>
+            <th className="py-2 px-3 text-center text-sm">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {config.map(item => {
+            const stat = stats[item.key];
+            const color = item.colorClass || "text-gray-700";
+            const totalColor = totalColorClass || color;
+            const maxAdded = Math.max(0, 5 - stat.base);
+            return (
+              <tr key={item.key} className="border-b border-gray-200">
+                <td className={`py-2 px-3 font-medium text-sm capitalize ${color}`}>{item.label}</td>
+                <td className="py-2 px-3">
+                  <Input
+                    type="number"
+                    value={stat.base}
+                    onChange={e => {
+                      const value = Math.max(
+                        minBase,
+                        Math.min(5, Number.parseInt(e.target.value) || minBase),
+                      );
+                      onChange(item.key, { ...stat, base: value });
+                    }}
+                    className="w-16 text-center text-sm"
+                    min={minBase}
+                    max={5}
+                  />
+                </td>
+                <td className="py-2 px-3">
+                  <Input
+                    type="number"
+                    value={stat.added}
+                    onChange={e => {
+                      const value = Math.min(
+                        maxAdded,
+                        Math.max(0, Number.parseInt(e.target.value) || 0),
+                      );
+                      onChange(item.key, { ...stat, added: value });
+                    }}
+                    className="w-16 text-center text-sm"
+                    min={0}
+                    max={maxAdded}
+                  />
+                </td>
+                <td className="py-2 px-3">
+                  <Input
+                    type="number"
+                    value={stat.bonus}
+                    onChange={e => {
+                      const value = Math.max(0, Number.parseInt(e.target.value) || 0);
+                      onChange(item.key, { ...stat, bonus: value });
+                    }}
+                    className="w-16 text-center text-sm"
+                    min={0}
+                  />
+                </td>
+                <td className={`py-2 px-3 font-bold text-center text-sm ${totalColor}`}>
+                  {getTotal(item.key)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="mt-2 text-xs text-gray-400 italic">Base + Added cannot exceed 5</div>
+    </div>
+  );
+}
+
+export default StatTable;

--- a/lib/stat-config.ts
+++ b/lib/stat-config.ts
@@ -1,0 +1,30 @@
+import type { AttributeType, AbilityType } from "./character-types";
+
+export interface StatConfig<T extends string> {
+  key: T;
+  label: string;
+  colorClass?: string;
+}
+
+export const attributeConfig: StatConfig<AttributeType>[] = [
+  { key: "fortitude", label: "Fortitude", colorClass: "text-green-600" },
+  { key: "finesse", label: "Finesse", colorClass: "text-blue-600" },
+  { key: "force", label: "Force", colorClass: "text-red-600" },
+];
+
+export const abilityConfig: StatConfig<AbilityType>[] = [
+  { key: "athletics", label: "Athletics" },
+  { key: "awareness", label: "Awareness" },
+  { key: "closeCombat", label: "Close Combat" },
+  { key: "craft", label: "Craft" },
+  { key: "embassy", label: "Embassy" },
+  { key: "integrity", label: "Integrity" },
+  { key: "navigate", label: "Navigate" },
+  { key: "physique", label: "Physique" },
+  { key: "presence", label: "Presence" },
+  { key: "performance", label: "Performance" },
+  { key: "rangedCombat", label: "Ranged Combat" },
+  { key: "sagacity", label: "Sagacity" },
+  { key: "stealth", label: "Stealth" },
+  { key: "war", label: "War" },
+];


### PR DESCRIPTION
## Summary
- add configurable stat table for attributes and abilities
- centralize attribute and ability metadata
- extract dice pool assembly into reusable component

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689635cf67b08332be40b38e15971b05