### PR TITLE
refactor: rely on direct character calculations

### DIFF
--- a/components/CharacterTabs.tsx
+++ b/components/CharacterTabs.tsx
@@ -19,8 +19,6 @@ interface CharacterTabsProps {
   character: Character;
   updateCharacter: (updates: Partial<Character>) => void;
   calculations: CharacterCalculations;
-  calculateSoak: () => number;
-  calculateHardness: () => number;
   calculateAbilityTotal: (abilityKey: AbilityType) => number;
   calculateDicePool: () => {
     basePool: number;
@@ -40,8 +38,6 @@ export function CharacterTabs({
   character,
   updateCharacter,
   calculations,
-  calculateSoak,
-  calculateHardness,
   calculateAbilityTotal,
   calculateDicePool,
   globalAbilityAttribute,
@@ -88,8 +84,6 @@ export function CharacterTabs({
           character={character}
           updateCharacter={updateCharacter}
           calculations={calculations}
-          calculateSoak={calculateSoak}
-          calculateHardness={calculateHardness}
         />
       </TabsContent>
 

--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -11,7 +11,6 @@ import type {
   Character,
   AttributeType,
   AbilityType,
-  ArmorPiece,
 } from "@/lib/character-types";
 import { calculateStatTotal } from "@/lib/exalted-utils";
 import { importCharacters, exportCharacter } from "@/lib/character-storage";
@@ -104,32 +103,6 @@ const ExaltedCharacterManager = () => {
     };
   };
 
-  const calculateSoak = () => {
-    if (!currentCharacter?.abilities?.physique) return 1;
-    const physique = calculateStatTotal(currentCharacter.abilities.physique);
-    let base = 1;
-    if (physique >= 3) base += 1;
-    const armorSoak = (currentCharacter?.armor || []).reduce(
-      (total: number, armor: ArmorPiece) =>
-        total + (Number.parseInt(String(armor.soak)) || 0),
-      0,
-    );
-    const modifier = currentCharacter?.staticValues?.soakModifier || 0;
-    return Math.max(0, base + armorSoak + Math.max(-5, Math.min(5, modifier)));
-  };
-
-  const calculateHardness = () => {
-    const essence = currentCharacter?.essence?.rating || 1;
-    const base = essence + 2;
-    const armorHardness = (currentCharacter?.armor || []).reduce(
-      (total: number, armor: ArmorPiece) =>
-        total + (Number.parseInt(String(armor.hardness)) || 0),
-      0,
-    );
-    const modifier = currentCharacter?.staticValues?.hardnessModifier || 0;
-    return Math.max(0, base + armorHardness + Math.max(-5, Math.min(5, modifier)));
-  };
-
   const handleExport = async (character: Character) => {
     try {
       await exportCharacter(character);
@@ -201,8 +174,6 @@ const ExaltedCharacterManager = () => {
             character={currentCharacter}
             updateCharacter={updateCharacter}
             calculations={calculations}
-            calculateSoak={calculateSoak}
-            calculateHardness={calculateHardness}
             calculateAbilityTotal={calculateAbilityTotal}
             calculateDicePool={calculateDicePool}
             globalAbilityAttribute={globalAbilityAttribute}

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -19,12 +19,10 @@ interface CombatTabProps {
   character: Character | null
   updateCharacter: (updates: Partial<Character>) => void
   calculations: CharacterCalculations
-  calculateSoak: () => number
-  calculateHardness: () => number
 }
 
 export const CombatTab: React.FC<CombatTabProps> = React.memo(
-  ({ character, updateCharacter, calculations, calculateSoak, calculateHardness }) => {
+  ({ character, updateCharacter, calculations }) => {
     const {
       getHighestAttribute,
       getTotalHealthLevels,
@@ -265,8 +263,6 @@ export const CombatTab: React.FC<CombatTabProps> = React.memo(
           character={character}
           updateCharacter={updateCharacter}
           calculations={calculations}
-          calculateSoak={calculateSoak}
-          calculateHardness={calculateHardness}
         />
 
         {/* Health Tracker */}

--- a/components/combat/StaticValuesPanel.tsx
+++ b/components/combat/StaticValuesPanel.tsx
@@ -9,16 +9,12 @@ interface StaticValuesPanelProps {
   character: Character
   updateCharacter: (updates: Partial<Character>) => void
   calculations: CharacterCalculations
-  calculateSoak: () => number
-  calculateHardness: () => number
 }
 
 export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
   character,
   updateCharacter,
   calculations,
-  calculateSoak,
-  calculateHardness,
 }) => {
   return (
     <Card>
@@ -156,7 +152,7 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
             {/* Soak */}
             <div className="space-y-2">
               <div className="text-center">
-                <div className="text-2xl font-bold text-yellow-600">{calculateSoak()}</div>
+                <div className="text-2xl font-bold text-yellow-600">{calculations.soak}</div>
                 <div className="text-sm font-medium text-gray-700">Soak</div>
               </div>
               <div className="text-xs text-gray-500 text-center">
@@ -193,7 +189,7 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
             {/* Hardness */}
             <div className="space-y-2">
               <div className="text-center">
-                <div className="text-2xl font-bold text-purple-600">{calculateHardness()}</div>
+                <div className="text-2xl font-bold text-purple-600">{calculations.hardness}</div>
                 <div className="text-sm font-medium text-gray-700">Hardness</div>
               </div>
               <div className="text-xs text-gray-500 text-center">


### PR DESCRIPTION
## Summary
- remove ad-hoc soak/hardness calculation callbacks
- consume static values directly from `useCharacterCalculations`
- clean up ExaltedCharacterManager and child tabs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689650f27ffc8332b5c4877f728f1a9b