### PR TITLE
feat: add NoCharacterCard component

### DIFF
--- a/components/character-tabs/AdvancementTab.tsx
+++ b/components/character-tabs/AdvancementTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, AdvancementEntry, AdvancementStatus } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 
 interface AdvancementTabProps {
   character: Character | null
@@ -86,15 +87,7 @@ export const AdvancementTab: React.FC<AdvancementTabProps> = React.memo(
     }
 
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return <NoCharacterCard />
     }
 
     return (

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -1,7 +1,6 @@
 // Combat Tab Component - Essence, health, static values, and combat mechanics
 
 import React from "react"
-import { Card, CardContent } from "@/components/ui/card"
 import { CombatRolls } from "@/components/combat/CombatRolls"
 import { StaticValuesPanel } from "@/components/combat/StaticValuesPanel"
 import { HealthTracker } from "@/components/combat/HealthTracker"
@@ -9,6 +8,7 @@ import type { Character } from "@/lib/character-types"
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations"
 import { useCombat } from "@/hooks/useCombat"
 import { EssencePanel } from "@/components/character-tabs/common/EssencePanel"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 import { createDefaultEssence } from "@/lib/character-defaults"
 
 interface CombatTabProps {
@@ -28,15 +28,7 @@ export const CombatTab: React.FC<CombatTabProps> = React.memo(
     } = useCombat({ character, updateCharacter, calculations })
 
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return <NoCharacterCard />
     }
 
     return (

--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -10,6 +10,7 @@ import { StatTable } from "@/components/forms/StatTable";
 import { attributeConfig, abilityConfig } from "@/lib/stat-config";
 import { DicePoolEditor } from "@/components/forms/DicePoolEditor";
 import { EssencePanel } from "@/components/character-tabs/common/EssencePanel";
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard";
 import { createDefaultEssence } from "@/lib/character-defaults";
 
 interface CoreStatsTabProps {
@@ -37,15 +38,7 @@ export const CoreStatsTab: React.FC<CoreStatsTabProps> = React.memo(
     setGlobalAbilityAttribute,
   }) => {
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      );
+      return <NoCharacterCard />;
     }
 
     const abilityTotalColor =

--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -22,6 +22,7 @@ import type {
   WeaponRange,
 } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 
 interface EquipmentTabProps {
   character: Character | null
@@ -140,15 +141,7 @@ export const EquipmentTab: React.FC<EquipmentTabProps> = React.memo(
     }
 
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return <NoCharacterCard />
     }
 
     return (

--- a/components/character-tabs/PowersTab.tsx
+++ b/components/character-tabs/PowersTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, Charm, Spell, SpellCircle } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 
 interface PowersTabProps {
   character: Character | null
@@ -122,15 +123,7 @@ export const PowersTab: React.FC<PowersTabProps> = React.memo(({ character, upda
   )
 
   if (!character) {
-    return (
-      <div className="space-y-6">
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-gray-500 italic">No character selected.</p>
-          </CardContent>
-        </Card>
-      </div>
-    )
+    return <NoCharacterCard />
   }
 
   return (

--- a/components/character-tabs/RulingsTab.tsx
+++ b/components/character-tabs/RulingsTab.tsx
@@ -16,6 +16,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import type { Character, Ruling } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 
 interface RulingsTabProps {
   character: Character | null
@@ -66,15 +67,7 @@ export const RulingsTab: React.FC<RulingsTabProps> = React.memo(
     )
 
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return <NoCharacterCard />
     }
 
     return (

--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -22,6 +22,7 @@ import type {
   BackgroundLevel,
 } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
+import { NoCharacterCard } from "@/components/character-tabs/common/NoCharacterCard"
 
 interface SocialTabProps {
   character: Character | null
@@ -167,15 +168,7 @@ export const SocialTab: React.FC<SocialTabProps> = React.memo(
     )
 
     if (!character) {
-      return (
-        <div className="space-y-6">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-gray-500 italic">No character selected.</p>
-            </CardContent>
-          </Card>
-        </div>
-      )
+      return <NoCharacterCard />
     }
 
     return (

--- a/components/character-tabs/common/NoCharacterCard.tsx
+++ b/components/character-tabs/common/NoCharacterCard.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+
+export function NoCharacterCard() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-gray-500 italic">No character selected.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default NoCharacterCard;


### PR DESCRIPTION
## Summary
- add reusable NoCharacterCard component for unselected character message
- replace duplicated placeholder blocks across character tabs

## Testing
- `npm test` *(fails: vite-tsconfig-paths resolved to an ESM file)*

------
https://chatgpt.com/codex/tasks/task_e_68967388207c8332b96429a39d810d6c