### PR TITLE
refactor: remove join battle bonus

### DIFF
--- a/components/combat/combatStories.helpers.ts
+++ b/components/combat/combatStories.helpers.ts
@@ -61,7 +61,6 @@ export const basicCharacter: Character = {
   spells: [],
   combat: {
     power: 0,
-    joinBattleBonus: 0,
     joinBattleDiceBonus: 0,
     joinBattleSuccessBonus: 0,
     decisiveExtraDice: 0,

--- a/lib/character-defaults.ts
+++ b/lib/character-defaults.ts
@@ -107,7 +107,6 @@ export const createDefaultDicePool = (): DicePool => ({
 // Default combat bonuses
 export const createDefaultCombat = (): Combat => ({
   power: 0,
-  joinBattleBonus: 0,
   joinBattleDiceBonus: 0,
   joinBattleSuccessBonus: 0,
   decisiveExtraDice: 0,

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -170,7 +170,6 @@ export interface Spell {
 
 export interface Combat {
   power: number
-  joinBattleBonus: number
   joinBattleDiceBonus: number
   joinBattleSuccessBonus: number
   decisiveExtraDice: number


### PR DESCRIPTION
## Summary
- remove deprecated joinBattleBonus from Combat interface and defaults
- update combat story helper to match new combat fields

## Testing
- `npm run type-check`
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file. ESM file cannot be loaded by `require`)*

------
https://chatgpt.com/codex/tasks/task_e_6896ac952e108332bbd2b1341557579e