### PR TITLE
Handle Enter key with onKeyDown in CharacterSelect

### DIFF
--- a/components/CharacterSelect.tsx
+++ b/components/CharacterSelect.tsx
@@ -144,7 +144,11 @@ export const CharacterSelect: React.FC<CharacterSelectProps> = ({
                 value={newCharacterName}
                 onChange={e => setNewCharacterName(e.target.value)}
                 placeholder="Character name..."
-                onKeyPress={e => e.key === "Enter" && handleCreate()}
+                onKeyDown={e => {
+                  if (e.key === "Enter") {
+                    handleCreate();
+                  }
+                }}
               />
               <Button onClick={handleCreate} disabled={!newCharacterName.trim()}>
                 <Plus className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- replace deprecated onKeyPress with onKeyDown for new character input
- trigger creation when Enter key is pressed

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b4bea78483328076be8e7d519192