### PR TITLE
fix: use compatible timeout type

### DIFF
--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -12,7 +12,7 @@ export const useAutoSave = <T,>(
 ): UseAutoSaveReturn => {
   const [isSaving, setIsSaving] = useState(false)
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (timeoutRef.current) {


### PR DESCRIPTION
## Summary
- use ReturnType<typeof setTimeout> for the autosave timeout ref to support both browser and Node builds

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file. ESM file cannot be loaded by `require`)*
- `npm run lint`
- `npm run type-check`
- `npx tsc --noEmit --module commonjs --moduleResolution node --types node --lib dom,esnext`


------
https://chatgpt.com/codex/tasks/task_e_6896b4c99ac88332909503046a8903d0