### PR TITLE
docs: update tab count to seven

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 - V0-accelerated character manager
 - Modern shadcn/ui component architecture
 - Complete character sheet functionality
-- 8-tab system
+- 7-tab system (Core Stats, Combat, Equipment, Powers, Socials, Advancement, Rulings)
 - Import/export system
 - Local storage persistence
 - Mobile-responsive design


### PR DESCRIPTION
## Summary
- update README to reference seven-tab layout and list individual tabs
- confirm other docs already reference seven tabs

## Testing
- `npm test` *(fails: vite-tsconfig-paths resolved to an ESM file)*

------
https://chatgpt.com/codex/tasks/task_e_6896b6677f288332933639ba1c79bd2e