### PR TITLE
refactor: use numeric armor values directly

### DIFF
--- a/lib/exalted-utils/static-values.ts
+++ b/lib/exalted-utils/static-values.ts
@@ -55,7 +55,7 @@ export const calculateSoak = (
   if (physiqueTotal >= 3) base += 1;
 
   const armorSoak = armor.reduce(
-    (total, armorPiece) => total + (Number.parseInt(armorPiece.soak.toString()) || 0),
+    (total, armorPiece) => total + armorPiece.soak,
     0,
   );
 
@@ -69,7 +69,7 @@ export const calculateHardness = (
 ): number => {
   const base = essenceRating + 2;
   const armorHardness = armor.reduce(
-    (total, armorPiece) => total + (Number.parseInt(armorPiece.hardness.toString()) || 0),
+    (total, armorPiece) => total + armorPiece.hardness,
     0,
   );
   return Math.max(0, base + armorHardness + clampModifier(hardnessModifier));


### PR DESCRIPTION
## Summary
- use numeric armor soak and hardness values directly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file cannot be loaded by `require`)*

------
https://chatgpt.com/codex/tasks/task_e_6896b6c7fe68833297cfba28a0895b2e