### PR TITLE
Refactor Ox-Body health calculations with lookup table

### DIFF
--- a/lib/exalted-utils/__tests__/health.test.ts
+++ b/lib/exalted-utils/__tests__/health.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { calculateHealthLevels } from "../health";
+import type { HealthLevels } from "../../character-types";
+
+describe("calculateHealthLevels", () => {
+  const baseline: HealthLevels = { zero: 0, minusOne: 0, minusTwo: 0, incap: 0 };
+
+  const lunarExpectations: HealthLevels[] = [
+    { zero: 0, minusOne: 0, minusTwo: 0, incap: 0 },
+    { zero: 1, minusOne: 2, minusTwo: 2, incap: 0 },
+    { zero: 2, minusOne: 4, minusTwo: 4, incap: 0 },
+    { zero: 3, minusOne: 6, minusTwo: 6, incap: 0 },
+    { zero: 4, minusOne: 8, minusTwo: 8, incap: 0 },
+    { zero: 5, minusOne: 10, minusTwo: 10, incap: 0 },
+  ];
+
+  lunarExpectations.forEach((expected, level) => {
+    it(`lunar with ${level} Ox-Body ranks`, () => {
+      expect(calculateHealthLevels(baseline, level, "lunar")).toEqual(expected);
+    });
+  });
+
+  const genericExpectations: HealthLevels[] = [
+    { zero: 0, minusOne: 0, minusTwo: 0, incap: 0 },
+    { zero: 0, minusOne: 1, minusTwo: 2, incap: 0 },
+    { zero: 0, minusOne: 2, minusTwo: 4, incap: 0 },
+    { zero: 0, minusOne: 3, minusTwo: 6, incap: 0 },
+    { zero: 0, minusOne: 4, minusTwo: 8, incap: 0 },
+    { zero: 0, minusOne: 5, minusTwo: 10, incap: 0 },
+  ];
+
+  genericExpectations.forEach((expected, level) => {
+    it(`generic with ${level} Ox-Body ranks`, () => {
+      expect(calculateHealthLevels(baseline, level, "solar")).toEqual(expected);
+    });
+  });
+});

--- a/lib/exalted-utils/health.ts
+++ b/lib/exalted-utils/health.ts
@@ -1,5 +1,23 @@
 import type { HealthLevels, ExaltType } from "../character-types";
 
+const GENERIC_OX_BODY_LEVELS: HealthLevels[] = Array.from({ length: 5 }, () => ({
+  zero: 0,
+  minusOne: 1,
+  minusTwo: 2,
+  incap: 0,
+}));
+
+const LUNAR_OX_BODY_LEVELS: HealthLevels[] = Array.from({ length: 5 }, () => ({
+  zero: 1,
+  minusOne: 2,
+  minusTwo: 2,
+  incap: 0,
+}));
+
+const OX_BODY_TABLE: Partial<Record<ExaltType, HealthLevels[]>> = {
+  lunar: LUNAR_OX_BODY_LEVELS,
+};
+
 export const calculateHealthLevels = (
   baseline: HealthLevels,
   oxBodyLevels: number,
@@ -12,42 +30,13 @@ export const calculateHealthLevels = (
   let oxBodyMinusTwo = 0;
   let oxBodyIncap = 0;
 
-  // Ox-Body calculations based on Exalt type
-  switch (exaltType) {
-    case "lunar":
-      // Lunar Ox-Body: +1 -0, +2 -1, +2 -2
-      if (clampedOxBody >= 1) {
-        oxBodyZero += 1;
-        oxBodyMinusOne += 2;
-        oxBodyMinusTwo += 2;
-      }
-      if (clampedOxBody >= 2) {
-        oxBodyZero += 1;
-        oxBodyMinusOne += 2;
-        oxBodyMinusTwo += 2;
-      }
-      if (clampedOxBody >= 3) {
-        oxBodyZero += 1;
-        oxBodyMinusOne += 2;
-        oxBodyMinusTwo += 2;
-      }
-      if (clampedOxBody >= 4) {
-        oxBodyZero += 1;
-        oxBodyMinusOne += 2;
-        oxBodyMinusTwo += 2;
-      }
-      if (clampedOxBody >= 5) {
-        oxBodyZero += 1;
-        oxBodyMinusOne += 2;
-        oxBodyMinusTwo += 2;
-      }
-      break;
-    default:
-      // Generic Ox-Body: +1 -1, +2 -2
-      for (let i = 0; i < clampedOxBody; i++) {
-        oxBodyMinusOne += 1;
-        oxBodyMinusTwo += 2;
-      }
+  const levels = OX_BODY_TABLE[exaltType] ?? GENERIC_OX_BODY_LEVELS;
+  for (let i = 0; i < clampedOxBody; i++) {
+    const bonus = levels[i];
+    oxBodyZero += bonus.zero;
+    oxBodyMinusOne += bonus.minusOne;
+    oxBodyMinusTwo += bonus.minusTwo;
+    oxBodyIncap += bonus.incap;
   }
 
   return {


### PR DESCRIPTION
## Summary
- replace sequential Ox-Body conditionals with lookup-driven loop
- add coverage for health calculations across Ox-Body ranks

## Testing
- `npx vitest run lib/exalted-utils/__tests__/health.test.ts --config vitest.temp.config.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6896b6c8b13883328f86075016ca0bd8