### PR TITLE
refactor: unify persistence with zustand

### DIFF
--- a/components/CharacterSelect.tsx
+++ b/components/CharacterSelect.tsx
@@ -102,8 +102,8 @@ export const CharacterSelect: React.FC<CharacterSelectProps> = ({
               </TooltipTrigger>
               <TooltipContent>
                 <p>
-                  Characters are automatically saved to your browser&apos;s
-                  local storage every 10 minutes
+                  Characters are saved automatically in your browser&apos;s local
+                  storage
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/components/CharacterToolbar.tsx
+++ b/components/CharacterToolbar.tsx
@@ -59,7 +59,7 @@ export function CharacterToolbar({
                 </div>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Characters are automatically saved to your browser&apos;s local storage every 10 minutes</p>
+                <p>Characters are saved automatically in your browser&apos;s local storage.</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -28,7 +28,7 @@ const ExaltedCharacterManager = () => {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { isSaving, lastSaved } = useAutoSave(characters, "exalted-characters");
+  const { isSaving, lastSaved } = useAutoSave(characters);
 
   const handleExport = async (character: Character) => {
     try {

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -7,7 +7,6 @@ interface UseAutoSaveReturn {
 
 export const useAutoSave = <T,>(
   data: T,
-  key: string,
   delay = 600000 // 10 minutes default
 ): UseAutoSaveReturn => {
   const [isSaving, setIsSaving] = useState(false)
@@ -20,10 +19,13 @@ export const useAutoSave = <T,>(
     }
 
     timeoutRef.current = setTimeout(() => {
+      // Persist middleware handles saving; we only update UI indicators
       setIsSaving(true)
-      localStorage.setItem(key, JSON.stringify(data))
-      setIsSaving(false)
-      setLastSaved(new Date())
+      // briefly show the saving state then update the timestamp
+      setTimeout(() => {
+        setIsSaving(false)
+        setLastSaved(new Date())
+      }, 500)
     }, delay)
 
     return () => {
@@ -31,7 +33,7 @@ export const useAutoSave = <T,>(
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [data, key, delay])
+  }, [data, delay])
 
   return { isSaving, lastSaved }
 }


### PR DESCRIPTION
## Summary
- rely on Zustand `persist` for character data storage
- refactor `useAutoSave` to only track save status
- update UI messaging about automatic saving

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6896ba04595c8332a3f7a0ef969c52ba