### PR TITLE
refactor: centralize equipment tag helpers

### DIFF
--- a/components/equipment/ArmorEditor.tsx
+++ b/components/equipment/ArmorEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import type { ArmorPiece, ArmorType } from "@/lib/character-types"
+import { parseTagsFromString, stringifyTags } from "@/components/equipment/tag-utils"
 
 interface ArmorEditorProps {
   armor: ArmorPiece
@@ -27,14 +28,6 @@ export const ArmorEditor: React.FC<ArmorEditorProps> = ({
   updateArmor,
   deleteArmor,
 }) => {
-  const parseTagsFromString = (tagString: string): string[] =>
-    tagString
-      .split(",")
-      .map(tag => tag.trim())
-      .filter(tag => tag.length > 0)
-
-  const stringifyTags = (tags: string[]): string => tags.join(", ")
-
   return (
     <div className="p-4 bg-white rounded border border-gray-200 space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">

--- a/components/equipment/WeaponEditor.tsx
+++ b/components/equipment/WeaponEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import type { Weapon, WeaponRange } from "@/lib/character-types"
+import { parseTagsFromString, stringifyTags } from "@/components/equipment/tag-utils"
 
 interface WeaponEditorProps {
   weapon: Weapon
@@ -27,14 +28,6 @@ export const WeaponEditor: React.FC<WeaponEditorProps> = ({
   updateWeapon,
   deleteWeapon,
 }) => {
-  const parseTagsFromString = (tagString: string): string[] =>
-    tagString
-      .split(",")
-      .map(tag => tag.trim())
-      .filter(tag => tag.length > 0)
-
-  const stringifyTags = (tags: string[]): string => tags.join(", ")
-
   return (
     <div className="p-4 bg-white rounded border border-gray-200 space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">

--- a/components/equipment/tag-utils.ts
+++ b/components/equipment/tag-utils.ts
@@ -1,0 +1,8 @@
+export const parseTagsFromString = (tagString: string): string[] =>
+  tagString
+    .split(",")
+    .map(tag => tag.trim())
+    .filter(tag => tag.length > 0)
+
+export const stringifyTags = (tags: string[]): string => tags.join(", ")
+


### PR DESCRIPTION
## Summary
- add shared tag-utils for parsing and stringifying equipment tags
- use shared helpers in ArmorEditor and WeaponEditor

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c328fed88332acb4f44b2abdc9f4