### PR TITLE
refactor: centralize modifier bounds

### DIFF
--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -22,6 +22,10 @@ import type {
 } from "@/lib/character-types"
 import { v4 as uuidv4 } from "uuid"
 import { useCharacterContext } from "@/hooks/CharacterContext"
+import {
+  DEFAULT_MODIFIER_MAX,
+  DEFAULT_MODIFIER_MIN,
+} from "@/lib/character-defaults"
 
 const virtueOptions: Array<NonNullable<VirtueType>> = [
   "ambition",
@@ -180,14 +184,20 @@ export const SocialTab: React.FC = React.memo(() => {
                 type="number"
                 value={character?.staticValues?.resolveModifier || 0}
                 onChange={e => {
-                  const value = Math.max(-5, Math.min(5, Number.parseInt(e.target.value) || 0))
+                  const value = Math.max(
+                    DEFAULT_MODIFIER_MIN,
+                    Math.min(
+                      DEFAULT_MODIFIER_MAX,
+                      Number.parseInt(e.target.value) || 0,
+                    ),
+                  )
                   updateCharacter({
                     staticValues: { ...character.staticValues, resolveModifier: value },
                   })
                 }}
                 className="w-12 text-center text-xs"
-                min={-5}
-                max={5}
+                min={DEFAULT_MODIFIER_MIN}
+                max={DEFAULT_MODIFIER_MAX}
               />
             </div>
           </div>

--- a/components/combat/CombatRolls.tsx
+++ b/components/combat/CombatRolls.tsx
@@ -5,6 +5,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { Character } from "@/lib/character-types"
 import { calculateStatTotal } from "@/lib/exalted-utils"
+import {
+  DEFAULT_MODIFIER_MAX,
+  DEFAULT_MODIFIER_MIN,
+} from "@/lib/character-defaults"
 
 interface CombatRollsProps {
   character: Character
@@ -59,16 +63,19 @@ export const CombatRolls: React.FC<CombatRollsProps> = ({
                     value={character?.combat?.joinBattleSuccessBonus || 0}
                     onChange={e => {
                       const value = Math.max(
-                        -5,
-                        Math.min(5, Number.parseInt(e.target.value) || 0),
+                        DEFAULT_MODIFIER_MIN,
+                        Math.min(
+                          DEFAULT_MODIFIER_MAX,
+                          Number.parseInt(e.target.value) || 0,
+                        ),
                       )
                       updateCharacter({
                         combat: { ...character.combat, joinBattleSuccessBonus: value },
                       })
                     }}
                     className="w-full text-center"
-                    min={-5}
-                    max={5}
+                    min={DEFAULT_MODIFIER_MIN}
+                    max={DEFAULT_MODIFIER_MAX}
                   />
                   <div className="text-xs text-gray-400">±5 cap</div>
                 </div>

--- a/components/combat/StaticValuesPanel.tsx
+++ b/components/combat/StaticValuesPanel.tsx
@@ -4,6 +4,10 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import type { Character } from "@/lib/character-types"
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations"
+import {
+  DEFAULT_MODIFIER_MAX,
+  DEFAULT_MODIFIER_MIN,
+} from "@/lib/character-defaults"
 
 interface StaticValuesPanelProps {
   character: Character
@@ -41,16 +45,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.defenseModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, defenseModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>
@@ -71,16 +78,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.evasionModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, evasionModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>
@@ -101,16 +111,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.parryModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, parryModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>
@@ -135,16 +148,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.resolveModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, resolveModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>
@@ -172,16 +188,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.soakModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, soakModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>
@@ -209,16 +228,19 @@ export const StaticValuesPanel: React.FC<StaticValuesPanelProps> = ({
                   value={character?.staticValues?.hardnessModifier || 0}
                   onChange={e => {
                     const value = Math.max(
-                      -5,
-                      Math.min(5, Number.parseInt(e.target.value) || 0),
+                      DEFAULT_MODIFIER_MIN,
+                      Math.min(
+                        DEFAULT_MODIFIER_MAX,
+                        Number.parseInt(e.target.value) || 0,
+                      ),
                     )
                     updateCharacter({
                       staticValues: { ...character.staticValues, hardnessModifier: value },
                     })
                   }}
                   className="w-12 text-center text-xs"
-                  min={-5}
-                  max={5}
+                  min={DEFAULT_MODIFIER_MIN}
+                  max={DEFAULT_MODIFIER_MAX}
                 />
               </div>
             </div>

--- a/components/forms/ModifierInputs.tsx
+++ b/components/forms/ModifierInputs.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import { DEFAULT_MODIFIER_MAX } from "@/lib/character-defaults";
 
 export const ModifierInputs: React.FC = () => {
   const { character, updateCharacter } = useCharacterContext();
@@ -112,7 +113,7 @@ export const ModifierInputs: React.FC = () => {
                   dicePool: {
                     ...character.dicePool,
                     extraSuccessBonus: Math.min(
-                      5,
+                      DEFAULT_MODIFIER_MAX,
                       Math.max(0, Number.parseInt(e.target.value) || 0),
                     ),
                   },
@@ -120,9 +121,11 @@ export const ModifierInputs: React.FC = () => {
               }
               className="text-center"
               min={0}
-              max={5}
+              max={DEFAULT_MODIFIER_MAX}
             />
-            <div className="text-xs text-gray-500 mt-1">Max: 5</div>
+            <div className="text-xs text-gray-500 mt-1">
+              Max: {DEFAULT_MODIFIER_MAX}
+            </div>
           </div>
           <div>
             <Label className="block text-sm font-medium text-gray-600 mb-1">

--- a/lib/exalted-utils/validation.ts
+++ b/lib/exalted-utils/validation.ts
@@ -1,5 +1,13 @@
+import {
+  DEFAULT_MODIFIER_MAX,
+  DEFAULT_MODIFIER_MIN,
+} from "../character-defaults";
+
 export const clampModifier = (value: number): number => {
-  return Math.max(-5, Math.min(5, value));
+  return Math.max(
+    DEFAULT_MODIFIER_MIN,
+    Math.min(DEFAULT_MODIFIER_MAX, value),
+  );
 };
 
 export const validateStatValue = (value: number): number => {


### PR DESCRIPTION
## Summary
- import default modifier constants and use them for clamping values
- ensure all modifier inputs share the same min/max bounds
- expose shared modifier clamp in validation utilities

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c33df41c8332b6735ee0625af26f