### PR TITLE
Use memoization for equipment tags

### DIFF
--- a/components/equipment/EquipmentTagReference.tsx
+++ b/components/equipment/EquipmentTagReference.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { ArmorPiece, Weapon } from "@/lib/character-types"
 
@@ -11,15 +11,17 @@ export const EquipmentTagReference: React.FC<EquipmentTagReferenceProps> = ({
   armor,
   weapons,
 }) => {
-  const items = [...armor, ...weapons]
-  const allTags = new Set<string>()
-  items.forEach(item => {
-    item.tags.forEach(tag => {
-      const trimmed = tag.trim()
-      if (trimmed) allTags.add(trimmed)
+  const { items, tags } = useMemo(() => {
+    const items = [...armor, ...weapons]
+    const allTags = new Set<string>()
+    items.forEach(item => {
+      item.tags.forEach(tag => {
+        const trimmed = tag.trim()
+        if (trimmed) allTags.add(trimmed)
+      })
     })
-  })
-  const tags = Array.from(allTags)
+    return { items, tags: Array.from(allTags) }
+  }, [armor, weapons])
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
- memoize equipment items and tag extraction for reference card

## Testing
- `npm test` *(fails: "vite-tsconfig-paths" resolved to an ESM file, cannot be loaded by require)*

------
https://chatgpt.com/codex/tasks/task_e_6896c5cb5fc88332adb43aa1685b73e5