### PR TITLE
Derive motes from essence rating

### DIFF
--- a/components/EssenceEditor.tsx
+++ b/components/EssenceEditor.tsx
@@ -11,11 +11,14 @@ interface EssenceEditorProps {
 
 export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(({ essence, onChange }) => {
   const update = (field: keyof Essence, value: number) => {
-    onChange({ ...essence, [field]: value });
+    const updated = { ...essence, [field]: value };
+    const rating = updated.rating ?? 0;
+    updated.motes = 5 + rating * 2;
+    onChange(updated);
   };
 
   const rating = essence.rating ?? 1;
-  const motes = essence.motes ?? 5;
+  const motes = 5 + rating * 2;
   const commitments = essence.commitments ?? 0;
   const spent = essence.spent ?? 0;
 
@@ -43,10 +46,7 @@ export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(({ essence
         <Input
           type="number"
           value={motes}
-          onChange={e => {
-            const value = Math.max(0, Math.min(50, Number.parseInt(e.target.value) || 0));
-            update("motes", value);
-          }}
+          readOnly
           className="w-20 text-center"
           min={0}
           max={50}

--- a/lib/character-defaults.ts
+++ b/lib/character-defaults.ts
@@ -50,7 +50,6 @@ export const createDefaultAbilities = (): Abilities => ({
 
 // Default essence pool
 export const createDefaultEssence = (): Essence => ({
-  motes: 5,
   commitments: 0,
   spent: 0,
   anima: 0,
@@ -144,22 +143,10 @@ export const createNewCharacter = (name: string): Character => ({
   rulings: [],
 });
 
-// Mapping of Exalt types to default mote values
-const defaultMotesByExaltType: Record<ExaltType, number> = {
-  solar: 7,
-  "dragon-blood": 4,
-  lunar: 5,
-  sidereal: 6,
-  abyssal: 7,
-  liminal: 5,
-  exigent: 5,
-};
-
 // Generic character template factory
 export const createCharacterTemplate = (name: string, type: ExaltType): Character => {
   const character = createNewCharacter(name);
   character.health.exaltType = type;
-  character.essence.motes = defaultMotesByExaltType[type];
   return character;
 };
 
@@ -186,8 +173,18 @@ export const createExigentCharacter = (name: string): Character =>
   createCharacterTemplate(name, "exigent");
 
 // Character template selector
+const EXALT_TYPES: ExaltType[] = [
+  "solar",
+  "dragon-blood",
+  "lunar",
+  "sidereal",
+  "abyssal",
+  "liminal",
+  "exigent",
+];
+
 export const createCharacterByType = (name: string, exaltType: string): Character => {
-  if (exaltType in defaultMotesByExaltType) {
+  if (EXALT_TYPES.includes(exaltType as ExaltType)) {
     return createCharacterTemplate(name, exaltType as ExaltType);
   }
   return createCharacterTemplate(name, "lunar"); // Default to Lunar

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -30,7 +30,7 @@ export interface Abilities {
 }
 
 export interface Essence {
-  motes: number;
+  motes?: number;
   commitments: number;
   spent: number;
   anima: number;


### PR DESCRIPTION
## Summary
- remove per-exalt mote defaults and default `motes` field in character creation
- derive motes as `5 + rating * 2` and make the motes field read-only in the Essence editor
- allow `motes` to be optional in `Essence` type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c9741fac8332b590d6fe0cb7cd02