### PR TITLE
Add zod schema for character data

### DIFF
--- a/hooks/useCharacterStore.ts
+++ b/hooks/useCharacterStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createNewCharacter } from "@/lib/character-defaults";
 import type { Character } from "@/lib/character-types";
+import { CharacterSchema } from "@/lib/character-schema";
 
 interface CharacterState {
   characters: Character[];
@@ -61,6 +62,17 @@ export const useCharacterStore = create<CharacterState>()(
         });
       },
     }),
-    { name: "exalted-characters" }
+    {
+      name: "exalted-characters",
+      deserialize: str => {
+        const data = JSON.parse(str);
+        if (data.state?.characters) {
+          data.state.characters = CharacterSchema.array().parse(data.state.characters);
+          data.state.currentCharacter =
+            data.state.characters.find((c: Character) => c.id === data.state.currentCharacterId) ?? null;
+        }
+        return data;
+      },
+    }
   )
 );

--- a/lib/__tests__/character-schema.test.ts
+++ b/lib/__tests__/character-schema.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { createNewCharacter } from "@/lib/character-defaults";
+import { CharacterSchema } from "@/lib/character-schema";
+
+describe("CharacterSchema", () => {
+  it("validates a newly created character", () => {
+    const char = createNewCharacter("Tester");
+    expect(() => CharacterSchema.parse(char)).not.toThrow();
+  });
+});
+

--- a/lib/character-schema.ts
+++ b/lib/character-schema.ts
@@ -1,0 +1,257 @@
+import { z } from "zod";
+
+// Stat blocks
+export const StatBlockSchema = z.object({
+  base: z.number(),
+  added: z.number(),
+  bonus: z.number(),
+});
+
+// Attributes and Abilities
+export const AttributesSchema = z.object({
+  fortitude: StatBlockSchema,
+  finesse: StatBlockSchema,
+  force: StatBlockSchema,
+});
+
+export const AbilitiesSchema = z.object({
+  athletics: StatBlockSchema,
+  awareness: StatBlockSchema,
+  closeCombat: StatBlockSchema,
+  craft: StatBlockSchema,
+  embassy: StatBlockSchema,
+  integrity: StatBlockSchema,
+  navigate: StatBlockSchema,
+  physique: StatBlockSchema,
+  presence: StatBlockSchema,
+  performance: StatBlockSchema,
+  rangedCombat: StatBlockSchema,
+  sagacity: StatBlockSchema,
+  stealth: StatBlockSchema,
+  war: StatBlockSchema,
+});
+
+// Essence and related values
+export const EssenceSchema = z.object({
+  motes: z.number(),
+  commitments: z.number(),
+  spent: z.number(),
+  anima: z.number(),
+  rating: z.number(),
+});
+
+export const StaticValuesSchema = z.object({
+  defenseModifier: z.number(),
+  evasionModifier: z.number(),
+  parryModifier: z.number(),
+  resolveModifier: z.number(),
+  soakModifier: z.number(),
+  hardnessModifier: z.number(),
+});
+
+export const HealthLevelsSchema = z.object({
+  zero: z.number(),
+  minusOne: z.number(),
+  minusTwo: z.number(),
+  incap: z.number(),
+});
+
+export const ExaltTypeSchema = z.enum([
+  "lunar",
+  "solar",
+  "dragon-blood",
+  "sidereal",
+  "abyssal",
+  "liminal",
+  "exigent",
+]);
+
+export const DramaticInjurySchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  isHealed: z.boolean(),
+});
+
+export const HealthSchema = z.object({
+  baseline: HealthLevelsSchema,
+  oxBodyLevels: z.number(),
+  exaltType: ExaltTypeSchema,
+  bashingDamage: z.number(),
+  lethalDamage: z.number(),
+  aggravatedDamage: z.number(),
+  dramaticInjuries: z.array(DramaticInjurySchema),
+});
+
+export const ArmorTypeSchema = z.enum(["light", "heavy"]);
+export const WeaponRangeSchema = z.enum(["close", "short", "mid", "long"]);
+
+export const ArmorPieceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: ArmorTypeSchema,
+  soak: z.number(),
+  hardness: z.number(),
+  mobility: z.number(),
+  tags: z.array(z.string()),
+  description: z.string().optional(),
+});
+
+export const WeaponSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  accuracy: z.number(),
+  damage: z.number(),
+  defence: z.number(),
+  overwhelming: z.number(),
+  range: WeaponRangeSchema,
+  tags: z.array(z.string()),
+  description: z.string().optional(),
+});
+
+export const MilestonesSchema = z.object({
+  personal: z.number(),
+  exalt: z.number(),
+  minor: z.number(),
+  major: z.number(),
+});
+
+export const AdvancementStatusSchema = z.enum([
+  "Planned",
+  "Paid with Personal",
+  "Paid with Exalt",
+  "Paid with Minor",
+  "Paid with Major",
+  "Initial",
+]);
+
+export const AdvancementEntrySchema = z.object({
+  id: z.string(),
+  item: z.string(),
+  status: AdvancementStatusSchema,
+  timestamp: z.string(),
+  description: z.string().optional(),
+});
+
+const AttributeTypeSchema = z.enum(["fortitude", "finesse", "force"]);
+const AbilityTypeSchema = z.enum([
+  "athletics",
+  "awareness",
+  "closeCombat",
+  "craft",
+  "embassy",
+  "integrity",
+  "navigate",
+  "physique",
+  "presence",
+  "performance",
+  "rangedCombat",
+  "sagacity",
+  "stealth",
+  "war",
+]);
+
+export const DicePoolSchema = z.object({
+  attribute: AttributeTypeSchema,
+  ability: AbilityTypeSchema,
+  targetNumber: z.number(),
+  doublesThreshold: z.number(),
+  extraDiceBonus: z.number(),
+  extraDiceNonBonus: z.number(),
+  extraSuccessBonus: z.number(),
+  extraSuccessNonBonus: z.number(),
+  isStunted: z.boolean(),
+});
+
+export const SpellCircleSchema = z.enum(["terrestrial", "celestial", "solar"]);
+
+export const CharmSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  cost: z.string(),
+  keywords: z.array(z.string()),
+  description: z.string(),
+  step: z.number().nullable(),
+  pageReference: z.string(),
+  prerequisites: z.array(z.string()),
+  dateAdded: z.string(),
+});
+
+export const SpellSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  circle: SpellCircleSchema,
+  cost: z.string(),
+  description: z.string(),
+  step: z.number().nullable(),
+  pageReference: z.string(),
+  dateAdded: z.string(),
+  components: z.array(z.string()),
+});
+
+export const CombatSchema = z.object({
+  power: z.number(),
+  joinBattleDiceBonus: z.number(),
+  joinBattleSuccessBonus: z.number(),
+  decisiveExtraDice: z.number(),
+  decisiveExtraSuccess: z.number(),
+});
+
+export const VirtueTypeSchema = z
+  .enum(["ambition", "compassion", "courage", "discipline", "justice", "loyalty", "wonder"])
+  .nullable();
+
+export const VirtuesSchema = z.object({
+  major: VirtueTypeSchema,
+  minor: VirtueTypeSchema,
+});
+
+export const IntimacySchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  intensity: z.enum(["minor", "major"]),
+});
+
+export const BackgroundTypeSchema = z.enum(["artifact", "resources", "followers"]);
+export const BackgroundLevelSchema = z.enum(["tertiary", "secondary", "primary"]);
+
+export const BackgroundSchema = z.object({
+  id: z.string(),
+  type: BackgroundTypeSchema,
+  level: BackgroundLevelSchema,
+  description: z.string(),
+});
+
+export const SocialSchema = z.object({
+  virtues: VirtuesSchema,
+  intimacies: z.array(IntimacySchema),
+  backgrounds: z.array(BackgroundSchema),
+});
+
+export const RulingSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  category: z.enum(["house-rule", "clarification", "edge-case"]),
+  dateCreated: z.string(),
+});
+
+export const CharacterSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  attributes: AttributesSchema,
+  abilities: AbilitiesSchema,
+  essence: EssenceSchema,
+  staticValues: StaticValuesSchema,
+  health: HealthSchema,
+  armor: z.array(ArmorPieceSchema),
+  weapons: z.array(WeaponSchema),
+  milestones: MilestonesSchema,
+  advancement: z.array(AdvancementEntrySchema),
+  dicePool: DicePoolSchema,
+  charms: z.array(CharmSchema),
+  spells: z.array(SpellSchema),
+  combat: CombatSchema,
+  social: SocialSchema,
+  rulings: z.array(RulingSchema),
+});
+

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -1,5 +1,6 @@
 import type { Character } from "@/lib/character-types";
 import { createNewCharacter } from "@/lib/character-defaults";
+import { CharacterSchema } from "@/lib/character-schema";
 import { v4 as uuidv4 } from "uuid";
 
 export async function exportCharacter(character: Character): Promise<void> {
@@ -42,9 +43,11 @@ export async function exportCharacters(
 export async function importCharacters(file: File): Promise<Character[]> {
   const text = await file.text();
   const importedData = JSON.parse(text);
-  const charactersToImport = Array.isArray(importedData) ? importedData : [importedData];
+  const characters = Array.isArray(importedData)
+    ? CharacterSchema.array().parse(importedData)
+    : [CharacterSchema.parse(importedData)];
 
-  return charactersToImport.map((char: Partial<Character>) => ({
+  return characters.map(char => ({
     ...createNewCharacter(char.name ?? "Unnamed"),
     ...char,
     id: uuidv4(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "sonner": "^1.5.0",
         "tailwind-merge": "^3.3.1",
         "uuid": "^11.0.2",
-        "zustand": "^5.0.0"
+        "zustand": "^5.0.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -55,6 +56,12 @@
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "",
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.0.2",
-    "zustand": "^5.0.0"
+    "zustand": "^5.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add Zod-based schemas for character structures
- validate imported characters and persisted store data using the schemas
- add test ensuring default character conforms to schema

## Testing
- `npm test` *(fails: Failed to resolve import "zod")*

------
https://chatgpt.com/codex/tasks/task_e_68995f6b3b5c8332841e43d24f5f4165