### PR TITLE
refactor: use react-hook-form for dice pool editing

### DIFF
--- a/components/forms/AbilitySelector.tsx
+++ b/components/forms/AbilitySelector.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -7,46 +6,56 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { useFormContext } from "react-hook-form";
 import { calculateStatTotal } from "@/lib/exalted-utils";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import type { DicePoolFormValues } from "@/lib/form-schemas";
 
 export const AbilitySelector: React.FC = () => {
-  const { character, updateCharacter } = useCharacterContext();
+  const { character } = useCharacterContext();
+  const { control } = useFormContext<DicePoolFormValues>();
 
   return (
-    <div>
-      <Label className="block text-sm font-medium text-gray-600 mb-1">Ability</Label>
-      <Select
-        value={character?.dicePool?.ability || "athletics"}
-        onValueChange={value =>
-          updateCharacter({
-            dicePool: {
-              ...character.dicePool,
-              ability: value as keyof typeof character.abilities,
-            },
-          })
-        }
-      >
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {Object.keys(character?.abilities || {}).map(ability => (
-            <SelectItem key={ability} value={ability}>
-              {ability.charAt(0).toUpperCase() + ability.slice(1).replace(/([A-Z])/g, " $1")} (
-              {calculateStatTotal(
-                character?.abilities?.[ability as keyof typeof character.abilities] || {
-                  base: 0,
-                  added: 0,
-                  bonus: 0,
-                }
-              )}
-              )
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <FormField
+      control={control}
+      name="ability"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+            Ability
+          </FormLabel>
+          <FormControl>
+            <Select onValueChange={field.onChange} value={field.value}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.keys(character?.abilities || {}).map(ability => (
+                  <SelectItem key={ability} value={ability}>
+                    {ability.charAt(0).toUpperCase() +
+                      ability.slice(1).replace(/([A-Z])/g, " $1")} (
+                    {calculateStatTotal(
+                      character?.abilities?.[
+                        ability as keyof typeof character.abilities
+                      ] || { base: 0, added: 0, bonus: 0 }
+                    )}
+                    )
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };
 

--- a/components/forms/AttributeSelector.tsx
+++ b/components/forms/AttributeSelector.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormControl,
+} from "@/components/ui/form";
+import { useFormContext } from "react-hook-form";
 import { calculateStatTotal } from "@/lib/exalted-utils";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import type { DicePoolFormValues } from "@/lib/form-schemas";
 
 const attributes = [
   {
@@ -26,38 +34,45 @@ const attributes = [
 ];
 
 export const AttributeSelector: React.FC = () => {
-  const { character, updateCharacter } = useCharacterContext();
+  const { character } = useCharacterContext();
+  const { control } = useFormContext<DicePoolFormValues>();
 
   return (
-    <div>
-      <Label className="block text-sm font-medium text-gray-600 mb-1">Attribute</Label>
-      <div className="flex gap-2">
-        {attributes.map(attr => (
-          <Button
-            key={attr.key}
-            variant={character?.dicePool?.attribute === attr.key ? "default" : "outline"}
-            size="sm"
-            onClick={() =>
-              updateCharacter({
-                dicePool: { ...character.dicePool, attribute: attr.key },
-              })
-            }
-            className={
-              character?.dicePool?.attribute === attr.key ? attr.activeClass : attr.inactiveClass
-            }
-          >
-            <div>{attr.label}</div>
-            <div className="text-xs opacity-75">
-              (
-              {calculateStatTotal(
-                character?.attributes?.[attr.key] || { base: 0, added: 0, bonus: 0 }
-              )}
-              )
+    <FormField
+      control={control}
+      name="attribute"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+            Attribute
+          </FormLabel>
+          <FormControl>
+            <div className="flex gap-2">
+              {attributes.map(attr => (
+                <Button
+                  key={attr.key}
+                  type="button"
+                  variant={field.value === attr.key ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => field.onChange(attr.key)}
+                  className={field.value === attr.key ? attr.activeClass : attr.inactiveClass}
+                >
+                  <div>{attr.label}</div>
+                  <div className="text-xs opacity-75">
+                    (
+                    {calculateStatTotal(
+                      character?.attributes?.[attr.key] || { base: 0, added: 0, bonus: 0 }
+                    )}
+                    )
+                  </div>
+                </Button>
+              ))}
             </div>
-          </Button>
-        ))}
-      </div>
-    </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };
 

--- a/components/forms/DicePoolEditor.tsx
+++ b/components/forms/DicePoolEditor.tsx
@@ -4,27 +4,56 @@ import AttributeSelector from "./AttributeSelector";
 import AbilitySelector from "./AbilitySelector";
 import ModifierInputs from "./ModifierInputs";
 import DicePoolSummary from "./DicePoolSummary";
+import { Form } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCharacterContext } from "@/hooks/CharacterContext";
+import { dicePoolFormSchema, type DicePoolFormValues } from "@/lib/form-schemas";
 
 export const DicePoolEditor: React.FC = React.memo(() => {
+  const { character, updateCharacter } = useCharacterContext();
+  const form = useForm<DicePoolFormValues>({
+    resolver: zodResolver(dicePoolFormSchema),
+    defaultValues: character.dicePool,
+    mode: "onChange",
+  });
+
+  React.useEffect(() => {
+    form.reset(character.dicePool);
+  }, [character, form]);
+
+  React.useEffect(() => {
+    const subscription = form.watch(value => {
+      if (form.formState.isValid) {
+        updateCharacter({ dicePool: value });
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateCharacter]);
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Roll Assembler</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid md:grid-cols-2 gap-6">
-          <div>
-            <h3 className="font-semibold text-gray-700 mb-3">Pool Assembly</h3>
-            <div className="space-y-3">
-              <AttributeSelector />
-              <AbilitySelector />
+    <Form {...form}>
+      <form onSubmit={e => e.preventDefault()}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Roll Assembler</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div>
+                <h3 className="font-semibold text-gray-700 mb-3">Pool Assembly</h3>
+                <div className="space-y-3">
+                  <AttributeSelector />
+                  <AbilitySelector />
+                </div>
+              </div>
+              <ModifierInputs />
             </div>
-          </div>
-          <ModifierInputs />
-        </div>
-        <DicePoolSummary />
-      </CardContent>
-    </Card>
+            <DicePoolSummary />
+          </CardContent>
+        </Card>
+      </form>
+    </Form>
   );
 });
 

--- a/components/forms/DicePoolEditor.tsx
+++ b/components/forms/DicePoolEditor.tsx
@@ -25,7 +25,7 @@ export const DicePoolEditor: React.FC = React.memo(() => {
   React.useEffect(() => {
     const subscription = form.watch(value => {
       if (form.formState.isValid) {
-        updateCharacter({ dicePool: value });
+        updateCharacter({ dicePool: dicePoolFormSchema.parse(value) });
       }
     });
     return () => subscription.unsubscribe();

--- a/components/forms/ModifierInputs.tsx
+++ b/components/forms/ModifierInputs.tsx
@@ -1,196 +1,186 @@
 import React from "react";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { useCharacterContext } from "@/hooks/CharacterContext";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
 import { DEFAULT_MODIFIER_MAX } from "@/lib/character-defaults";
-import { DicePoolSchema } from "@/lib/character-types";
-import { z } from "zod";
+import { useFormContext } from "react-hook-form";
+import type { DicePoolFormValues } from "@/lib/form-schemas";
 
 export const ModifierInputs: React.FC = () => {
-  const { character, updateCharacter } = useCharacterContext();
-
-  const [values, setValues] = React.useState({
-    targetNumber: String(character?.dicePool?.targetNumber || 7),
-    doublesThreshold: String(character?.dicePool?.doublesThreshold || 10),
-    extraDiceBonus: String(character?.dicePool?.extraDiceBonus || 0),
-    extraDiceNonBonus: String(character?.dicePool?.extraDiceNonBonus || 0),
-    extraSuccessBonus: String(character?.dicePool?.extraSuccessBonus || 0),
-    extraSuccessNonBonus: String(character?.dicePool?.extraSuccessNonBonus || 0),
-  });
-
-  const [errors, setErrors] = React.useState<Record<string, string>>({});
-
-  React.useEffect(() => {
-    setValues({
-      targetNumber: String(character?.dicePool?.targetNumber || 7),
-      doublesThreshold: String(character?.dicePool?.doublesThreshold || 10),
-      extraDiceBonus: String(character?.dicePool?.extraDiceBonus || 0),
-      extraDiceNonBonus: String(character?.dicePool?.extraDiceNonBonus || 0),
-      extraSuccessBonus: String(character?.dicePool?.extraSuccessBonus || 0),
-      extraSuccessNonBonus: String(character?.dicePool?.extraSuccessNonBonus || 0),
-    });
-  }, [character]);
-
-  const fieldSchemas: Record<string, z.ZodTypeAny> = {
-    targetNumber: DicePoolSchema.shape.targetNumber,
-    doublesThreshold: DicePoolSchema.shape.doublesThreshold,
-    extraDiceBonus: DicePoolSchema.shape.extraDiceBonus,
-    extraDiceNonBonus: DicePoolSchema.shape.extraDiceNonBonus,
-    extraSuccessBonus: DicePoolSchema.shape.extraSuccessBonus,
-    extraSuccessNonBonus: DicePoolSchema.shape.extraSuccessNonBonus,
-  };
-
-  const handleChange = (field: keyof typeof values) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const val = e.target.value;
-      setValues(prev => ({ ...prev, [field]: val }));
-      const schema = fieldSchemas[field];
-      const result = schema.safeParse(Number(val));
-      if (result.success) {
-        setErrors(prev => ({ ...prev, [field]: "" }));
-        updateCharacter({
-          dicePool: { ...character.dicePool, [field]: result.data },
-        });
-      } else {
-        setErrors(prev => ({
-          ...prev,
-          [field]: result.error.issues[0]?.message || "Invalid value",
-        }));
-      }
-    };
+  const { control } = useFormContext<DicePoolFormValues>();
 
   return (
     <div>
       <h3 className="font-semibold text-gray-700 mb-3">Modifiers</h3>
       <div className="space-y-3">
         <div className="grid grid-cols-2 gap-3">
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">Target Number</Label>
-            <Input
-              type="number"
-              value={values.targetNumber}
-              onChange={handleChange("targetNumber")}
-              className="text-center"
-              min={1}
-              max={10}
-              aria-invalid={Boolean(errors.targetNumber)}
-            />
-            {errors.targetNumber && (
-              <p className="text-xs text-red-500 mt-1">{errors.targetNumber}</p>
+          <FormField
+            control={control}
+            name="targetNumber"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Target Number
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={1}
+                    max={10}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">
-              Doubles Threshold
-            </Label>
-            <Input
-              type="number"
-              value={values.doublesThreshold}
-              onChange={handleChange("doublesThreshold")}
-              className="text-center"
-              min={1}
-              max={10}
-              aria-invalid={Boolean(errors.doublesThreshold)}
-            />
-            {errors.doublesThreshold && (
-              <p className="text-xs text-red-500 mt-1">{errors.doublesThreshold}</p>
-            )}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">
-              Extra Dice (Bonus)
-            </Label>
-            <Input
-              type="number"
-              value={values.extraDiceBonus}
-              onChange={handleChange("extraDiceBonus")}
-              className="text-center"
-              min={0}
-              max={10}
-              aria-invalid={Boolean(errors.extraDiceBonus)}
-            />
-            <div className="text-xs text-gray-500 mt-1">Max: 10</div>
-            {errors.extraDiceBonus && (
-              <p className="text-xs text-red-500 mt-1">{errors.extraDiceBonus}</p>
-            )}
-          </div>
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">
-              Extra Dice (Non-Bonus)
-            </Label>
-            <Input
-              type="number"
-              value={values.extraDiceNonBonus}
-              onChange={handleChange("extraDiceNonBonus")}
-              className="text-center"
-              min={0}
-              aria-invalid={Boolean(errors.extraDiceNonBonus)}
-            />
-            {errors.extraDiceNonBonus && (
-              <p className="text-xs text-red-500 mt-1">{errors.extraDiceNonBonus}</p>
-            )}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">
-              Extra Success (Bonus)
-            </Label>
-            <Input
-              type="number"
-              value={values.extraSuccessBonus}
-              onChange={handleChange("extraSuccessBonus")}
-              className="text-center"
-              min={0}
-              max={DEFAULT_MODIFIER_MAX}
-              aria-invalid={Boolean(errors.extraSuccessBonus)}
-            />
-            <div className="text-xs text-gray-500 mt-1">Max: {DEFAULT_MODIFIER_MAX}</div>
-            {errors.extraSuccessBonus && (
-              <p className="text-xs text-red-500 mt-1">{errors.extraSuccessBonus}</p>
-            )}
-          </div>
-          <div>
-            <Label className="block text-sm font-medium text-gray-600 mb-1">
-              Extra Success (Non-Bonus)
-            </Label>
-            <Input
-              type="number"
-              value={values.extraSuccessNonBonus}
-              onChange={handleChange("extraSuccessNonBonus")}
-              className="text-center"
-              min={0}
-              aria-invalid={Boolean(errors.extraSuccessNonBonus)}
-            />
-            {errors.extraSuccessNonBonus && (
-              <p className="text-xs text-red-500 mt-1">{errors.extraSuccessNonBonus}</p>
-            )}
-          </div>
-        </div>
-
-        <div className="mt-4 flex items-center gap-2">
-          <input
-            type="checkbox"
-            id="stunt-checkbox"
-            checked={character?.dicePool?.isStunted || false}
-            onChange={e =>
-              updateCharacter({
-                dicePool: {
-                  ...character.dicePool,
-                  isStunted: e.target.checked,
-                },
-              })
-            }
-            className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
           />
-          <Label htmlFor="stunt-checkbox" className="text-sm font-medium text-gray-700">
-            Stunt (+2 dice, non-capped)
-          </Label>
+          <FormField
+            control={control}
+            name="doublesThreshold"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Doubles Threshold
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={1}
+                    max={10}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={control}
+            name="extraDiceBonus"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Extra Dice (Bonus)
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={0}
+                    max={10}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <div className="text-xs text-gray-500 mt-1">Max: 10</div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="extraDiceNonBonus"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Extra Dice (Non-Bonus)
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={0}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={control}
+            name="extraSuccessBonus"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Extra Success (Bonus)
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={0}
+                    max={DEFAULT_MODIFIER_MAX}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <div className="text-xs text-gray-500 mt-1">
+                  Max: {DEFAULT_MODIFIER_MAX}
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="extraSuccessNonBonus"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="block text-sm font-medium text-gray-600 mb-1">
+                  Extra Success (Non-Bonus)
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    min={0}
+                    value={field.value}
+                    onChange={e => field.onChange(Number(e.target.value))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={control}
+          name="isStunted"
+          render={({ field }) => (
+            <FormItem className="mt-4 flex items-center gap-2">
+              <FormControl>
+                <input
+                  type="checkbox"
+                  checked={field.value}
+                  onChange={e => field.onChange(e.target.checked)}
+                  className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                />
+              </FormControl>
+              <FormLabel className="text-sm font-medium text-gray-700">
+                Stunt (+2 dice, non-capped)
+              </FormLabel>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
       </div>
     </div>
   );

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue = {
+  name: string;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({ ...props }: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  return {
+    name: fieldContext.name,
+    formItemId: `${fieldContext.name}-form-item`,
+    formDescriptionId: `${fieldContext.name}-form-item-description`,
+    formMessageId: `${fieldContext.name}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("space-y-2", className)} {...props} />
+));
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof Label>,
+  React.ComponentPropsWithoutRef<typeof Label>
+>(({ className, ...props }, ref) => {
+  const { formItemId } = useFormField();
+  return <Label ref={ref} className={cn(className)} htmlFor={formItemId} {...props} />;
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { formItemId } = useFormField();
+  return <Slot ref={ref} id={formItemId} {...props} />;
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-gray-500", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { formMessageId, error } = useFormField();
+  const body = children ?? error?.message;
+  if (!body) return null;
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-xs text-red-500", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+};
+

--- a/lib/form-schemas.ts
+++ b/lib/form-schemas.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { DicePoolSchema, CharacterSchema } from "./character-types";
+
+export const dicePoolFormSchema = DicePoolSchema;
+export type DicePoolFormValues = z.infer<typeof dicePoolFormSchema>;
+
+export const characterFormSchema = CharacterSchema;
+export type CharacterFormValues = z.infer<typeof characterFormSchema>;

--- a/package.json
+++ b/package.json
@@ -86,9 +86,11 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^9.0.1",
+    "react-hook-form": "^7.51.5",
     "sonner": "^1.5.0",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.0.2",
+    "@hookform/resolvers": "^3.9.0",
     "zod": "^4.0.17",
     "zustand": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- add react-hook-form and resolver deps
- implement shadcn `Form` utilities and zod form schemas
- refactor dice pool editors to use `useForm` with validation messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997b15d04083328c460ccb09c4c77b