### PR TITLE
feat: enhance character store middleware

### DIFF
--- a/hooks/useCharacterStore.ts
+++ b/hooks/useCharacterStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, subscribeWithSelector } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
 import { createNewCharacter } from "@/lib/character-defaults";
 import { CharacterSchema, type Character } from "@/lib/character-types";
 
@@ -15,71 +16,81 @@ interface CharacterState {
 }
 
 export const useCharacterStore = create<CharacterState>()(
-  persist(
-    (set, get) => ({
-      characters: [],
-      currentCharacterId: null,
-      currentCharacter: null,
-      addCharacter: name => {
-        const char = createNewCharacter(name);
-        set({
-          characters: [...get().characters, char],
-          currentCharacterId: char.id,
-          currentCharacter: char,
-        });
-      },
-      updateCurrentCharacter: updates => {
-        const { currentCharacterId, characters, currentCharacter } = get();
-        if (!currentCharacterId || !currentCharacter) return;
-        const updated = { ...currentCharacter, ...updates };
-        set({
-          currentCharacter: updated,
-          characters: characters.map(c => (c.id === currentCharacterId ? updated : c)),
-        });
-      },
-      deleteCharacter: id => {
-        const remaining = get().characters.filter(c => c.id !== id);
-        const newCurrentId =
-          id === get().currentCharacterId ? (remaining[0]?.id ?? null) : get().currentCharacterId;
-        set({
-          characters: remaining,
-          currentCharacterId: newCurrentId,
-          currentCharacter: remaining.find(c => c.id === newCurrentId) ?? null,
-        });
-      },
-      setCurrentCharacter: id => {
-        set({
-          currentCharacterId: id,
-          currentCharacter: get().characters.find(c => c.id === id) ?? null,
-        });
-      },
-      loadCharacters: characters => {
-        const parsed = CharacterSchema.array().parse(characters) as Character[];
-        set({
-          characters: parsed,
-          currentCharacterId: parsed[0]?.id ?? null,
-          currentCharacter: parsed[0] ?? null,
-        });
-      },
-    }),
-    {
-      name: "exalted-characters",
-      merge: (persistedState, currentState) => {
-        try {
-          const persisted = persistedState as Partial<CharacterState>;
-          const parsed = CharacterSchema.array().parse(persisted.characters) as Character[];
-          const currentCharacter =
-            parsed.find(c => c.id === persisted.currentCharacterId) ?? parsed[0] ?? null;
-          return {
-            ...currentState,
-            characters: parsed,
-            currentCharacterId: currentCharacter?.id ?? null,
-            currentCharacter,
-          };
-        } catch {
-          return currentState;
-        }
-      },
-    }
+  subscribeWithSelector(
+    persist(
+      immer((set, get) => ({
+        characters: [],
+        currentCharacterId: null,
+        currentCharacter: null,
+        addCharacter: name => {
+          const char = createNewCharacter(name);
+          set(state => {
+            state.characters.push(char);
+            state.currentCharacterId = char.id;
+            state.currentCharacter = char;
+          });
+        },
+        updateCurrentCharacter: updates => {
+          const id = get().currentCharacterId;
+          if (!id) return;
+          set(state => {
+            const char = state.characters.find(c => c.id === id);
+            if (!char) return;
+            Object.assign(char, updates);
+            state.currentCharacter = char;
+          });
+        },
+        deleteCharacter: id => {
+          set(state => {
+            state.characters = state.characters.filter(c => c.id !== id);
+            if (id === state.currentCharacterId) {
+              state.currentCharacterId = state.characters[0]?.id ?? null;
+              state.currentCharacter = state.characters[0] ?? null;
+            } else {
+              state.currentCharacter =
+                state.characters.find(c => c.id === state.currentCharacterId) ?? null;
+            }
+          });
+        },
+        setCurrentCharacter: id => {
+          set(state => {
+            state.currentCharacterId = id;
+            state.currentCharacter = state.characters.find(c => c.id === id) ?? null;
+          });
+        },
+        loadCharacters: characters => {
+          const parsed = CharacterSchema.array().parse(characters) as Character[];
+          set(state => {
+            state.characters = parsed;
+            state.currentCharacterId = parsed[0]?.id ?? null;
+            state.currentCharacter = parsed[0] ?? null;
+          });
+        },
+      })),
+      {
+        name: "exalted-characters",
+        merge: (persistedState, currentState) => {
+          try {
+            const persisted = persistedState as Partial<CharacterState>;
+            const parsed = CharacterSchema.array().parse(persisted.characters) as Character[];
+            const currentCharacter =
+              parsed.find(c => c.id === persisted.currentCharacterId) ?? parsed[0] ?? null;
+            return {
+              ...currentState,
+              characters: parsed,
+              currentCharacterId: currentCharacter?.id ?? null,
+              currentCharacter,
+            };
+          } catch {
+            return currentState;
+          }
+        },
+      }
+    )
   )
 );
+
+export const subscribeToCharacterStore = <T>(
+  selector: (state: CharacterState) => T,
+  listener: (state: T, prev: T) => void
+) => useCharacterStore.subscribe(selector, listener);

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "uuid": "^11.0.2",
     "@hookform/resolvers": "^3.9.0",
     "zod": "^4.0.17",
-    "zustand": "^5.0.0"
+    "zustand": "^5.0.0",
+    "immer": "^10.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- wrap character store with `immer` and `subscribeWithSelector`
- refactor mutations to use mutable immer style
- add helper for selector-based subscriptions
- include `immer` package for middleware support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689980914d408332b3bd06517e9f3144