### PR TITLE
feat: migrate character store to dexie

### DIFF
--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -73,8 +73,7 @@ export async function backupDatabase(
   }, 100);
 }
 
-export async function restoreDatabase(file: File): Promise<void> {
-  const blob = file instanceof Blob ? file : new Blob([await file.arrayBuffer()]);
+export async function restoreDatabase(blob: Blob): Promise<void> {
   await importInto(db, blob, { clearTablesBeforeImport: true });
   await useCharacterStore.persist.rehydrate();
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,43 @@
+import Dexie, { type Table } from "dexie";
+import { CharacterSchema, type Character } from "@/lib/character-types";
+
+interface Metadata {
+  key: string;
+  value: string | null;
+}
+
+class ExaltedDB extends Dexie {
+  public characters!: Table<Character, string>;
+  public metadata!: Table<Metadata, string>;
+
+  constructor() {
+    super("exalted-character-db");
+
+    this.version(1)
+      .stores({
+        characters: "&id,name",
+        metadata: "&key",
+      })
+      .upgrade(async tx => {
+        if (typeof window === "undefined") return;
+        const raw = window.localStorage.getItem("exalted-characters");
+        if (!raw) return;
+        try {
+          const parsed = JSON.parse(raw) as {
+            state?: { characters?: unknown[]; currentCharacterId?: string | null };
+          };
+          const characters = CharacterSchema.array().parse(parsed.state?.characters ?? []);
+          await tx.table("characters").bulkPut(characters as Character[]);
+          await tx
+            .table("metadata")
+            .put({ key: "currentCharacterId", value: parsed.state?.currentCharacterId ?? null });
+          window.localStorage.removeItem("exalted-characters");
+        } catch {
+          // ignore invalid migrations
+        }
+      });
+  }
+}
+
+export const db = new ExaltedDB();
+

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Table } from "dexie";
-import { CharacterSchema, type Character } from "@/lib/character-types";
+import { type Character } from "@/lib/character-types";
 
 interface Metadata {
   key: string;
@@ -13,29 +13,10 @@ class ExaltedDB extends Dexie {
   constructor() {
     super("exalted-character-db");
 
-    this.version(1)
-      .stores({
-        characters: "&id,name",
-        metadata: "&key",
-      })
-      .upgrade(async tx => {
-        if (typeof window === "undefined") return;
-        const raw = window.localStorage.getItem("exalted-characters");
-        if (!raw) return;
-        try {
-          const parsed = JSON.parse(raw) as {
-            state?: { characters?: unknown[]; currentCharacterId?: string | null };
-          };
-          const characters = CharacterSchema.array().parse(parsed.state?.characters ?? []);
-          await tx.table("characters").bulkPut(characters as Character[]);
-          await tx
-            .table("metadata")
-            .put({ key: "currentCharacterId", value: parsed.state?.currentCharacterId ?? null });
-          window.localStorage.removeItem("exalted-characters");
-        } catch {
-          // ignore invalid migrations
-        }
-      });
+    this.version(1).stores({
+      characters: "&id,name",
+      metadata: "&key",
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
     "@hookform/resolvers": "^3.9.0",
     "zod": "^4.0.17",
     "zustand": "^5.0.0",
-    "immer": "^10.1.1"
+    "immer": "^10.1.1",
+    "dexie": "^4.0.3",
+    "dexie-export-import": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add Dexie and export/import dependency for indexed storage
- migrate Zustand character store to Dexie-backed persistence
- provide database backup and restore helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899a2f315b8833291ad59df1317a031