### PR TITLE
feat: use superjson for data serialization

### DIFF
--- a/hooks/useCharacterStore.ts
+++ b/hooks/useCharacterStore.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand";
-import { persist, subscribeWithSelector } from "zustand/middleware";
+import { persist, subscribeWithSelector, type PersistStorage } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { createNewCharacter } from "@/lib/character-defaults";
 import { CharacterSchema, type Character } from "@/lib/character-types";
+import superjson from "superjson";
 
 interface CharacterState {
   characters: Character[];
@@ -69,6 +70,18 @@ export const useCharacterStore = create<CharacterState>()(
       })),
       {
         name: "exalted-characters",
+        storage: {
+          getItem: name => {
+            const str = localStorage.getItem(name);
+            return str ? superjson.parse(str) : null;
+          },
+          setItem: (name, value) => {
+            localStorage.setItem(name, superjson.stringify(value));
+          },
+          removeItem: name => {
+            localStorage.removeItem(name);
+          },
+        } as PersistStorage<CharacterState>,
         merge: (persistedState, currentState) => {
           try {
             const persisted = persistedState as Partial<CharacterState>;

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -1,9 +1,10 @@
 import { CharacterSchema, type Character } from "@/lib/character-types";
 import { createNewCharacter } from "@/lib/character-defaults";
 import { v4 as uuidv4 } from "uuid";
+import superjson from "superjson";
 
 export async function exportCharacter(character: Character): Promise<void> {
-  const dataStr = JSON.stringify(character, null, 2);
+  const dataStr = superjson.stringify(character, { space: 2 });
   const dataBlob = new Blob([dataStr], { type: "application/json" });
   const link = document.createElement("a");
   const url = window.URL.createObjectURL(dataBlob);
@@ -24,7 +25,7 @@ export async function exportCharacters(
   characters: Character[],
   filename = "all_exalted_characters.json"
 ): Promise<void> {
-  const dataStr = JSON.stringify(characters, null, 2);
+  const dataStr = superjson.stringify(characters, { space: 2 });
   const dataBlob = new Blob([dataStr], { type: "application/json" });
   const link = document.createElement("a");
   const url = window.URL.createObjectURL(dataBlob);
@@ -41,7 +42,12 @@ export async function exportCharacters(
 
 export async function importCharacters(file: File): Promise<Character[]> {
   const text = await file.text();
-  const importedData = JSON.parse(text);
+  let importedData: unknown;
+  try {
+    importedData = superjson.parse(text);
+  } catch {
+    importedData = JSON.parse(text);
+  }
   const parsed: Character[] = Array.isArray(importedData)
     ? (CharacterSchema.array().parse(importedData) as Character[])
     : [CharacterSchema.parse(importedData) as Character];

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-markdown": "^9.0.1",
     "react-hook-form": "^7.51.5",
     "sonner": "^1.5.0",
+    "superjson": "^2.2.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.0.2",
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add superjson dependency
- use superjson to persist character store state
- serialize and parse character exports with superjson

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899ab920d008332ad85706646dac745