### PR TITLE
feat: integrate react-table for stats and equipment tables

### DIFF
--- a/components/equipment/EquipmentTagReference.tsx
+++ b/components/equipment/EquipmentTagReference.tsx
@@ -1,5 +1,15 @@
 import React, { useMemo } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import type { ArmorPiece, Weapon } from "@/lib/character-types";
 
 interface EquipmentTagReferenceProps {
@@ -8,8 +18,14 @@ interface EquipmentTagReferenceProps {
 }
 
 export const EquipmentTagReference: React.FC<EquipmentTagReferenceProps> = ({ armor, weapons }) => {
-  const { items, tags } = useMemo(() => {
-    const items = [...armor, ...weapons];
+  const items = useMemo(() => [...armor, ...weapons], [armor, weapons]);
+
+  interface TagRow {
+    tag: string;
+    items: string;
+  }
+
+  const data = useMemo<TagRow[]>(() => {
     const allTags = new Set<string>();
     items.forEach(item => {
       item.tags.forEach(tag => {
@@ -17,8 +33,63 @@ export const EquipmentTagReference: React.FC<EquipmentTagReferenceProps> = ({ ar
         if (trimmed) allTags.add(trimmed);
       });
     });
-    return { items, tags: Array.from(allTags) };
-  }, [armor, weapons]);
+    return Array.from(allTags).map(tag => ({
+      tag,
+      items: items
+        .filter(item => item.tags.includes(tag))
+        .map(item => item.name || "Unnamed")
+        .join(", "),
+    }));
+  }, [items]);
+
+  const columns = React.useMemo<ColumnDef<TagRow>[]>(
+    () => [
+      {
+        accessorKey: "tag",
+        header: ({ column }) => (
+          <button
+            className="text-left"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Tag
+          </button>
+        ),
+        cell: ({ row }) => (
+          <span className="font-medium text-gray-700">{row.getValue("tag")}</span>
+        ),
+      },
+      {
+        accessorKey: "items",
+        header: ({ column }) => (
+          <button
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="text-left"
+          >
+            Used On
+          </button>
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs text-gray-500">{row.getValue("items")}</span>
+        ),
+      },
+    ],
+    []
+  );
+
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState("");
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: "includesString",
+  });
 
   return (
     <Card>
@@ -26,26 +97,56 @@ export const EquipmentTagReference: React.FC<EquipmentTagReferenceProps> = ({ ar
         <CardTitle>Equipment Tag Reference</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="space-y-2">
-          {tags.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-              {tags.sort().map((tag, index) => (
-                <div key={index} className="p-2 bg-gray-50 rounded border border-gray-200">
-                  <span className="font-medium text-gray-700">{tag}</span>
-                  <div className="text-xs text-gray-500 mt-1">
-                    Used on{" "}
-                    {items
-                      .filter(item => item.tags.includes(tag))
-                      .map(item => item.name || "Unnamed")
-                      .join(", ")}
-                  </div>
-                </div>
-              ))}
+        {data.length > 0 ? (
+          <div className="space-y-2">
+            <Input
+              placeholder="Filter tags..."
+              value={globalFilter}
+              onChange={e => setGlobalFilter(e.target.value)}
+              className="mb-2"
+            />
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-100">
+                  {table.getHeaderGroups().map(headerGroup => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(header => (
+                        <th key={header.id} className="py-2 px-3 text-left text-sm">
+                          {header.isPlaceholder ? null : (
+                            <div
+                              className={header.column.getCanSort() ? "cursor-pointer select-none" : ""}
+                              onClick={header.column.getToggleSortingHandler()}
+                            >
+                              {flexRender(header.column.columnDef.header, header.getContext())}
+                              {
+                                { asc: " ▲", desc: " ▼" }[
+                                  header.column.getIsSorted() as string
+                                ] ?? null
+                              }
+                            </div>
+                          )}
+                        </th>
+                      ))}
+                    </tr>
+                  ))}
+                </thead>
+                <tbody>
+                  {table.getRowModel().rows.map(row => (
+                    <tr key={row.id} className="border-b border-gray-200">
+                      {row.getVisibleCells().map(cell => (
+                        <td key={cell.id} className="py-2 px-3 text-left text-sm">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          ) : (
-            <p className="text-gray-500 italic">No equipment tags to reference.</p>
-          )}
-        </div>
+          </div>
+        ) : (
+          <p className="text-gray-500 italic">No equipment tags to reference.</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/forms/StatTable.tsx
+++ b/components/forms/StatTable.tsx
@@ -1,4 +1,13 @@
 import React from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
 import { Input } from "@/components/ui/input";
 import { type StatBlock } from "@/lib/character-types";
 import type { StatConfig } from "@/lib/stat-config";
@@ -25,79 +34,219 @@ export function StatTable<T extends string>({
   const wrapperClass = scrollable ? "max-h-96 overflow-y-auto" : "overflow-x-auto";
   const theadClass = scrollable ? "sticky top-0 bg-gray-100" : "bg-gray-100";
 
+  interface StatRow {
+    key: T;
+    label: string;
+    colorClass: string;
+    stat: StatBlock;
+  }
+
+  const data = React.useMemo<StatRow[]>(
+    () =>
+      config.map(item => ({
+        key: item.key,
+        label: item.label,
+        colorClass: item.colorClass || "text-gray-700",
+        stat: stats[item.key],
+      })),
+    [config, stats]
+  );
+
+  const columns = React.useMemo<ColumnDef<StatRow>[]>(
+    () => [
+      {
+        accessorKey: "label",
+        header: ({ column }) => (
+          <button
+            className="text-left"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Name
+          </button>
+        ),
+        cell: ({ row }) => (
+          <span
+            className={`font-medium text-sm capitalize ${row.original.colorClass}`}
+          >
+            {row.getValue<string>("label")}
+          </span>
+        ),
+      },
+      {
+        id: "base",
+        accessorFn: row => row.stat.base,
+        header: ({ column }) => (
+          <button
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="w-full text-center"
+          >
+            Base
+          </button>
+        ),
+        cell: ({ row }) => {
+          const stat = row.original.stat;
+          return (
+            <Input
+              type="number"
+              value={stat.base}
+              onChange={e => {
+                const value = Math.max(
+                  minBase,
+                  Math.min(5, Number.parseInt(e.target.value) || minBase)
+                );
+                onChange(row.original.key, { ...stat, base: value });
+              }}
+              className="w-16 text-center text-sm"
+              min={minBase}
+              max={5}
+            />
+          );
+        },
+      },
+      {
+        id: "added",
+        accessorFn: row => row.stat.added,
+        header: ({ column }) => (
+          <button
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="w-full text-center"
+          >
+            Added
+          </button>
+        ),
+        cell: ({ row }) => {
+          const stat = row.original.stat;
+          const maxAdded = Math.max(0, 5 - stat.base);
+          return (
+            <Input
+              type="number"
+              value={stat.added}
+              onChange={e => {
+                const value = Math.min(
+                  maxAdded,
+                  Math.max(0, Number.parseInt(e.target.value) || 0)
+                );
+                onChange(row.original.key, { ...stat, added: value });
+              }}
+              className="w-16 text-center text-sm"
+              min={0}
+              max={maxAdded}
+            />
+          );
+        },
+      },
+      {
+        id: "bonus",
+        accessorFn: row => row.stat.bonus,
+        header: ({ column }) => (
+          <button
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="w-full text-center"
+          >
+            Bonus
+          </button>
+        ),
+        cell: ({ row }) => {
+          const stat = row.original.stat;
+          return (
+            <Input
+              type="number"
+              value={stat.bonus}
+              onChange={e => {
+                const value = Math.max(0, Number.parseInt(e.target.value) || 0);
+                onChange(row.original.key, { ...stat, bonus: value });
+              }}
+              className="w-16 text-center text-sm"
+              min={0}
+            />
+          );
+        },
+      },
+      {
+        id: "total",
+        accessorFn: row => getTotal(row.key),
+        header: ({ column }) => (
+          <button
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="w-full text-center"
+          >
+            Total
+          </button>
+        ),
+        cell: ({ row }) => (
+          <span
+            className={`font-bold text-center text-sm ${
+              totalColorClass || row.original.colorClass
+            }`}
+          >
+            {row.getValue<number>("total")}
+          </span>
+        ),
+      },
+    ],
+    [minBase, onChange, getTotal, totalColorClass]
+  );
+
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState("");
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: "includesString",
+  });
+
   return (
     <div className={wrapperClass}>
+      <Input
+        placeholder="Filter stats..."
+        value={globalFilter}
+        onChange={e => setGlobalFilter(e.target.value)}
+        className="mb-2"
+      />
       <table className="w-full">
         <thead className={theadClass}>
-          <tr>
-            <th className="py-2 px-3 text-left text-sm">Name</th>
-            <th className="py-2 px-3 text-center text-sm">Base</th>
-            <th className="py-2 px-3 text-center text-sm">Added</th>
-            <th className="py-2 px-3 text-center text-sm">Bonus</th>
-            <th className="py-2 px-3 text-center text-sm">Total</th>
-          </tr>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <th
+                  key={header.id}
+                  className="py-2 px-3 text-sm"
+                >
+                  {header.isPlaceholder ? null : (
+                    <div
+                      className={header.column.getCanSort() ? "cursor-pointer select-none" : ""}
+                      onClick={header.column.getToggleSortingHandler()}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {
+                        { asc: " ▲", desc: " ▼" }[
+                          header.column.getIsSorted() as string
+                        ] ?? null
+                      }
+                    </div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
         </thead>
         <tbody>
-          {config.map(item => {
-            const stat = stats[item.key];
-            const color = item.colorClass || "text-gray-700";
-            const totalColor = totalColorClass || color;
-            const maxAdded = Math.max(0, 5 - stat.base);
-            return (
-              <tr key={item.key} className="border-b border-gray-200">
-                <td className={`py-2 px-3 font-medium text-sm capitalize ${color}`}>
-                  {item.label}
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id} className="border-b border-gray-200">
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id} className="py-2 px-3 text-center text-sm">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
-                <td className="py-2 px-3">
-                  <Input
-                    type="number"
-                    value={stat.base}
-                    onChange={e => {
-                      const value = Math.max(
-                        minBase,
-                        Math.min(5, Number.parseInt(e.target.value) || minBase)
-                      );
-                      onChange(item.key, { ...stat, base: value });
-                    }}
-                    className="w-16 text-center text-sm"
-                    min={minBase}
-                    max={5}
-                  />
-                </td>
-                <td className="py-2 px-3">
-                  <Input
-                    type="number"
-                    value={stat.added}
-                    onChange={e => {
-                      const value = Math.min(
-                        maxAdded,
-                        Math.max(0, Number.parseInt(e.target.value) || 0)
-                      );
-                      onChange(item.key, { ...stat, added: value });
-                    }}
-                    className="w-16 text-center text-sm"
-                    min={0}
-                    max={maxAdded}
-                  />
-                </td>
-                <td className="py-2 px-3">
-                  <Input
-                    type="number"
-                    value={stat.bonus}
-                    onChange={e => {
-                      const value = Math.max(0, Number.parseInt(e.target.value) || 0);
-                      onChange(item.key, { ...stat, bonus: value });
-                    }}
-                    className="w-16 text-center text-sm"
-                    min={0}
-                  />
-                </td>
-                <td className={`py-2 px-3 font-bold text-center text-sm ${totalColor}`}>
-                  {getTotal(item.key)}
-                </td>
-              </tr>
-            );
-          })}
+              ))}
+            </tr>
+          ))}
         </tbody>
       </table>
       <div className="mt-2 text-xs text-gray-400 italic">Base + Added cannot exceed 5</div>

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@tanstack/react-table": "^8.20.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",


### PR DESCRIPTION
## Summary
- add `@tanstack/react-table` dependency
- convert stats table to use `useReactTable` with sorting/filtering
- add sortable, filterable equipment tag reference table

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fe2f548c8332b0e67013ddc04e0d