### PR TITLE
Add drag-and-drop sorting for equipment lists

### DIFF
--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -48,6 +48,13 @@ export const EquipmentTab: React.FC = React.memo(() => {
     [character, updateCharacter]
   );
 
+  const reorderArmor = useCallback(
+    (armorList: ArmorPiece[]) => {
+      updateCharacter({ armor: armorList });
+    },
+    [updateCharacter]
+  );
+
   const addWeapon = useCallback(() => {
     const newWeapon: Weapon = {
       id: uuidv4(),
@@ -86,6 +93,13 @@ export const EquipmentTab: React.FC = React.memo(() => {
     [character, updateCharacter]
   );
 
+  const reorderWeapons = useCallback(
+    (weaponList: Weapon[]) => {
+      updateCharacter({ weapons: weaponList });
+    },
+    [updateCharacter]
+  );
+
   return (
     <div className="space-y-6">
       <ArmorList
@@ -93,6 +107,7 @@ export const EquipmentTab: React.FC = React.memo(() => {
         addArmor={addArmor}
         updateArmor={updateArmor}
         deleteArmor={deleteArmor}
+        reorderArmor={reorderArmor}
       />
 
       <WeaponList
@@ -100,6 +115,7 @@ export const EquipmentTab: React.FC = React.memo(() => {
         addWeapon={addWeapon}
         updateWeapon={updateWeapon}
         deleteWeapon={deleteWeapon}
+        reorderWeapons={reorderWeapons}
       />
 
       <EquipmentTagReference armor={character.armor || []} weapons={character.weapons || []} />

--- a/components/equipment/ArmorList.tsx
+++ b/components/equipment/ArmorList.tsx
@@ -4,47 +4,90 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ArmorPiece } from "@/lib/character-types";
 import { ArmorEditor } from "@/components/equipment/ArmorEditor";
+import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 
 interface ArmorListProps {
   armor: ArmorPiece[];
   addArmor: () => void;
   updateArmor: (id: string, field: keyof ArmorPiece, value: ArmorPiece[keyof ArmorPiece]) => void;
   deleteArmor: (id: string) => void;
+  reorderArmor: (armor: ArmorPiece[]) => void;
 }
+
+const SortableArmorItem: React.FC<{
+  piece: ArmorPiece;
+  updateArmor: (id: string, field: keyof ArmorPiece, value: ArmorPiece[keyof ArmorPiece]) => void;
+  deleteArmor: (id: string) => void;
+}> = ({ piece, updateArmor, deleteArmor }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: piece.id,
+  });
+  const style: React.CSSProperties = {
+    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <ArmorEditor armor={piece} updateArmor={updateArmor} deleteArmor={deleteArmor} />
+    </div>
+  );
+};
 
 export const ArmorList: React.FC<ArmorListProps> = ({
   armor,
   addArmor,
   updateArmor,
   deleteArmor,
-}) => (
-  <Card>
-    <CardHeader>
-      <CardTitle className="flex items-center justify-between">
-        Armor
-        <Button onClick={addArmor} size="sm" className="bg-gray-600 hover:bg-gray-700">
-          <Plus className="w-4 h-4 mr-1" />
-          Add Armor
-        </Button>
-      </CardTitle>
-    </CardHeader>
-    <CardContent>
-      {armor.length === 0 ? (
-        <p className="text-gray-500 italic">No armor equipped.</p>
-      ) : (
-        <div className="space-y-4">
-          {armor.map(piece => (
-            <ArmorEditor
-              key={piece.id}
-              armor={piece}
-              updateArmor={updateArmor}
-              deleteArmor={deleteArmor}
-            />
-          ))}
-        </div>
-      )}
-    </CardContent>
-  </Card>
-);
+  reorderArmor,
+}) => {
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = armor.findIndex(a => a.id === active.id);
+    const newIndex = armor.findIndex(a => a.id === over.id);
+    if (oldIndex !== -1 && newIndex !== -1) {
+      reorderArmor(arrayMove(armor, oldIndex, newIndex));
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          Armor
+          <Button onClick={addArmor} size="sm" className="bg-gray-600 hover:bg-gray-700">
+            <Plus className="w-4 h-4 mr-1" />
+            Add Armor
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {armor.length === 0 ? (
+          <p className="text-gray-500 italic">No armor equipped.</p>
+        ) : (
+          <DndContext onDragEnd={handleDragEnd}>
+            <SortableContext items={armor.map(a => a.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-4">
+                {armor.map(piece => (
+                  <SortableArmorItem
+                    key={piece.id}
+                    piece={piece}
+                    updateArmor={updateArmor}
+                    deleteArmor={deleteArmor}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
 
 ArmorList.displayName = "ArmorList";

--- a/components/equipment/WeaponList.tsx
+++ b/components/equipment/WeaponList.tsx
@@ -4,47 +4,90 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Weapon } from "@/lib/character-types";
 import { WeaponEditor } from "@/components/equipment/WeaponEditor";
+import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 
 interface WeaponListProps {
   weapons: Weapon[];
   addWeapon: () => void;
   updateWeapon: (id: string, field: keyof Weapon, value: Weapon[keyof Weapon]) => void;
   deleteWeapon: (id: string) => void;
+  reorderWeapons: (weapons: Weapon[]) => void;
 }
+
+const SortableWeaponItem: React.FC<{
+  weapon: Weapon;
+  updateWeapon: (id: string, field: keyof Weapon, value: Weapon[keyof Weapon]) => void;
+  deleteWeapon: (id: string) => void;
+}> = ({ weapon, updateWeapon, deleteWeapon }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: weapon.id,
+  });
+  const style: React.CSSProperties = {
+    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <WeaponEditor weapon={weapon} updateWeapon={updateWeapon} deleteWeapon={deleteWeapon} />
+    </div>
+  );
+};
 
 export const WeaponList: React.FC<WeaponListProps> = ({
   weapons,
   addWeapon,
   updateWeapon,
   deleteWeapon,
-}) => (
-  <Card>
-    <CardHeader>
-      <CardTitle className="flex items-center justify-between">
-        Weapons
-        <Button onClick={addWeapon} size="sm" className="bg-red-600 hover:bg-red-700">
-          <Plus className="w-4 h-4 mr-1" />
-          Add Weapon
-        </Button>
-      </CardTitle>
-    </CardHeader>
-    <CardContent>
-      {weapons.length === 0 ? (
-        <p className="text-gray-500 italic">No weapons equipped.</p>
-      ) : (
-        <div className="space-y-4">
-          {weapons.map(w => (
-            <WeaponEditor
-              key={w.id}
-              weapon={w}
-              updateWeapon={updateWeapon}
-              deleteWeapon={deleteWeapon}
-            />
-          ))}
-        </div>
-      )}
-    </CardContent>
-  </Card>
-);
+  reorderWeapons,
+}) => {
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = weapons.findIndex(w => w.id === active.id);
+    const newIndex = weapons.findIndex(w => w.id === over.id);
+    if (oldIndex !== -1 && newIndex !== -1) {
+      reorderWeapons(arrayMove(weapons, oldIndex, newIndex));
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          Weapons
+          <Button onClick={addWeapon} size="sm" className="bg-red-600 hover:bg-red-700">
+            <Plus className="w-4 h-4 mr-1" />
+            Add Weapon
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {weapons.length === 0 ? (
+          <p className="text-gray-500 italic">No weapons equipped.</p>
+        ) : (
+          <DndContext onDragEnd={handleDragEnd}>
+            <SortableContext items={weapons.map(w => w.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-4">
+                {weapons.map(w => (
+                  <SortableWeaponItem
+                    key={w.id}
+                    weapon={w}
+                    updateWeapon={updateWeapon}
+                    deleteWeapon={deleteWeapon}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
 
 WeaponList.displayName = "WeaponList";

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "ci:format": "npm run format:check"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6",
+    "@dnd-kit/sortable": "^7",
+    "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
@@ -82,20 +85,19 @@
     "@tanstack/react-table": "^8.20.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "immer": "^10.1.1",
     "lucide-react": "^0.525.0",
     "next": "15.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-markdown": "^9.0.1",
     "react-hook-form": "^7.51.5",
+    "react-markdown": "^9.0.1",
     "sonner": "^1.5.0",
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.0.2",
-    "@hookform/resolvers": "^3.9.0",
     "zod": "^4.0.17",
-    "zustand": "^5.0.0",
-    "immer": "^10.1.1"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add `@dnd-kit/core` and `@dnd-kit/sortable` dependencies
- enable drag-and-drop reordering for armor and weapons
- persist reordered equipment in character store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a113a7dc4833286fa2096a3ac67d3