### PR TITLE
Replace local storage persistence with Dexie

### DIFF
--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -9,6 +9,7 @@ import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCharacterManagement } from "@/hooks/useCharacterManagement";
 import type { Character } from "@/lib/character-types";
 import { importCharacters, exportCharacter } from "@/lib/character-storage";
+import { saveCharacter } from "@/lib/db";
 import { toast } from "sonner";
 
 const ExaltedCharacterManager = () => {
@@ -41,7 +42,10 @@ const ExaltedCharacterManager = () => {
   const handleImport = async (file: File) => {
     try {
       const imported = await importCharacters(file);
-      loadCharacters([...characters, ...imported]);
+      for (const char of imported) {
+        await saveCharacter(char);
+      }
+      await loadCharacters();
       if (imported.length === 1) {
         selectCharacter(imported[0].id);
       }


### PR DESCRIPTION
## Summary
- remove localStorage-based persistence from character store
- load and persist characters via Dexie, including new async loader
- save imported characters to Dexie before refreshing store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a198418048332955b252041cd4403