### PR TITLE
Guard Dexie initialization for server environments

### DIFF
--- a/hooks/useCharacterStore.ts
+++ b/hooks/useCharacterStore.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -19,26 +19,31 @@ class ExaltedDB extends Dexie {
   }
 }
 
-export const db = new ExaltedDB();
+export const db = typeof window !== "undefined" ? new ExaltedDB() : null;
 
 export async function getAllCharacters(): Promise<Character[]> {
+  if (!db) return [];
   return db.characters.toArray();
 }
 
 export async function saveCharacter(character: Character): Promise<void> {
+  if (!db) return;
   await db.characters.put(character);
 }
 
 export async function deleteCharacter(id: string): Promise<void> {
+  if (!db) return;
   await db.characters.delete(id);
 }
 
 export async function getCurrentCharacterId(): Promise<string | null> {
+  if (!db) return null;
   const entry = await db.meta.get("currentCharacterId");
   return entry?.value ?? null;
 }
 
 export async function setCurrentCharacterId(id: string | null): Promise<void> {
+  if (!db) return;
   if (id === null) {
     await db.meta.delete("currentCharacterId");
   } else {


### PR DESCRIPTION
## Summary
- guard Dexie database initialization behind a `window` check so it only runs client-side
- mark `useCharacterStore` as a client hook to ensure Dexie is used in client context

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689a20d280cc8332b7ddaa8075102a5a