### PR TITLE
Persist imported characters and export from Dexie

### DIFF
--- a/components/CharacterSelect.tsx
+++ b/components/CharacterSelect.tsx
@@ -94,7 +94,7 @@ export const CharacterSelect: React.FC<CharacterSelectProps> = ({
               className="hidden"
             />
             {characters.length > 0 && (
-              <Button variant="outline" onClick={() => exportCharacters(characters)}>
+              <Button variant="outline" onClick={() => exportCharacters()}>
                 <Download className="w-4 h-4 mr-2" />
                 Export All
               </Button>

--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -9,7 +9,6 @@ import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCharacterManagement } from "@/hooks/useCharacterManagement";
 import type { Character } from "@/lib/character-types";
 import { importCharacters, exportCharacter } from "@/lib/character-storage";
-import { saveCharacter } from "@/lib/db";
 import { toast } from "sonner";
 
 const ExaltedCharacterManager = () => {
@@ -42,9 +41,6 @@ const ExaltedCharacterManager = () => {
   const handleImport = async (file: File) => {
     try {
       const imported = await importCharacters(file);
-      for (const char of imported) {
-        await saveCharacter(char);
-      }
       await loadCharacters();
       if (imported.length === 1) {
         selectCharacter(imported[0].id);

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -62,7 +62,7 @@ export async function importCharacters(file: File): Promise<Character[]> {
   }));
 
   if (db) {
-    await db.characters.bulkPut(characters);
+    await Promise.all(characters.map(char => db.characters.put(char)));
   }
 
   return characters;


### PR DESCRIPTION
## Summary
- Save imported characters directly into Dexie within `importCharacters` for persistent storage
- Export all characters by syncing from Dexie after waiting for store saves
- Update UI to use new Dexie-backed export and rely on automatic import persistence

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a229a347883328a1269bfd1c4a969