### PR TITLE
Log caught errors for character management and markdown loading

### DIFF
--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -33,7 +33,8 @@ const ExaltedCharacterManager = () => {
   const handleExport = async (character: Character) => {
     try {
       await exportCharacter(character);
-    } catch {
+    } catch (err) {
+      console.error(err);
       toast.error("Failed to export character. Please try again.");
     }
   };
@@ -46,7 +47,8 @@ const ExaltedCharacterManager = () => {
         selectCharacter(imported[0].id);
       }
       toast.success(`Successfully imported ${imported.length} character(s)`);
-    } catch {
+    } catch (err) {
+      console.error(err);
       toast.error(
         "Failed to import character(s). Please ensure the file is a valid character export."
       );

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -22,6 +22,7 @@ export default function SiteFooter() {
         const legalText = await legalResponse.text();
         setLegalContent(legalText);
       } catch (error) {
+        console.error(error);
         setAboutContent("# About\n\nInformation about this application.");
         setLegalContent("# Legal\n\nLegal information and disclaimers.");
       }

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -48,8 +48,14 @@ export async function importCharacters(file: File): Promise<Character[]> {
   let importedData: unknown;
   try {
     importedData = superjson.parse(text);
-  } catch {
-    importedData = JSON.parse(text);
+  } catch (err) {
+    console.error("Failed to parse with superjson:", err);
+    try {
+      importedData = JSON.parse(text);
+    } catch (jsonErr) {
+      console.error("Failed to parse with JSON:", jsonErr);
+      throw new Error("Unable to parse character data");
+    }
   }
   const parsed: Character[] = Array.isArray(importedData)
     ? (CharacterSchema.array().parse(importedData) as Character[])


### PR DESCRIPTION
## Summary
- log caught errors in character export/import before displaying toast messages
- add detailed logging when parsing imported character data fails
- output markdown loading errors for fallback content in footer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3ea1569c8332aa989b57ca2e7355