### PR TITLE
Enable strict TypeScript checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Thank you for your interest in improving the **Exalted: Essence Character Manage
 
 - Use **functional React components** and hooks.
 - Follow **TypeScript** best practices.
+- Run `npm run type-check` to ensure the project passes strict type checking.
 - Apply **Tailwind CSS** classes consistently.
 - Write defensive code (null checks, fallbacks).
 

--- a/components/ExaltedCharacterManager.tsx
+++ b/components/ExaltedCharacterManager.tsx
@@ -26,7 +26,7 @@ const ExaltedCharacterManager = () => {
 
   const [activeTab, setActiveTab] = useState("core");
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null!);
 
   const { isSaving, lastSaved } = useAutoSave(characters);
 

--- a/hooks/useCharacterCalculations.ts
+++ b/hooks/useCharacterCalculations.ts
@@ -34,8 +34,8 @@ export interface CharacterCalculations {
 
   // Attribute/ability helpers
   highestAttribute: number;
-  getAttributeTotal: (attributeKey: string) => number;
-  getAbilityTotal: (abilityKey: string) => number;
+  getAttributeTotal: (attributeKey: AttributeType) => number;
+  getAbilityTotal: (abilityKey: AbilityType) => number;
 
   // Dice pool calculation
   dicePoolResult: DicePoolResult;

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -62,7 +62,8 @@ export async function importCharacters(file: File): Promise<Character[]> {
   }));
 
   if (db) {
-    await Promise.all(characters.map(char => db.characters.put(char)));
+    const database = db;
+    await Promise.all(characters.map(char => database.characters.put(char)));
   }
 
   return characters;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
+    "skipLibCheck": false,
+    "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
@@ -13,13 +12,16 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@hookform/resolvers/zod": ["types/hookform-zod-module"],
+      "@hookform/resolvers/zod/dist/types": ["types/hookform-zod"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/types/hookform-zod-module.d.ts
+++ b/types/hookform-zod-module.d.ts
@@ -1,0 +1,4 @@
+declare module "@hookform/resolvers/zod" {
+  import type { Resolver } from "@hookform/resolvers/zod/dist/types";
+  export const zodResolver: Resolver;
+}

--- a/types/hookform-zod.d.ts
+++ b/types/hookform-zod.d.ts
@@ -1,0 +1,16 @@
+declare module "@hookform/resolvers/zod/dist/types" {
+  import type { FieldValues, ResolverOptions, ResolverResult } from "react-hook-form";
+  import type { z } from "zod";
+  export type Resolver = <T extends z.Schema<any, any>>(
+    schema: T,
+    schemaOptions?: any,
+    factoryOptions?: {
+      mode?: "async" | "sync";
+      raw?: boolean;
+    }
+  ) => <TFieldValues extends FieldValues, TContext>(
+    values: TFieldValues,
+    context: TContext | undefined,
+    options: ResolverOptions<TFieldValues>
+  ) => Promise<ResolverResult<TFieldValues>>;
+}

--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -1,0 +1,14 @@
+import { JSX as ReactJSX } from "react";
+
+declare global {
+  namespace JSX {
+    type Element = ReactJSX.Element;
+    type ElementClass = ReactJSX.ElementClass;
+    type ElementAttributesProperty = ReactJSX.ElementAttributesProperty;
+    type ElementChildrenAttribute = ReactJSX.ElementChildrenAttribute;
+    type IntrinsicElements = ReactJSX.IntrinsicElements;
+    type IntrinsicAttributes = ReactJSX.IntrinsicAttributes;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- enable strict TypeScript compilation with library checks and add module path mappings
- fix type issues in character manager, calculations hook, and storage helpers
- document strict type-checking requirement in contributing guide

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3ee643d4833286f0bc67d6c095bf