### PR TITLE
docs: add community links and streamline legal text

### DIFF
--- a/public/content/about.md
+++ b/public/content/about.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This is a digital character manager built specifically for **Exalted: Essence**. It aims to provide a streamlined, user-friendly way to create and manage your characters for the game.
+This is a digital character manager built specifically for **Exalted: Essence**.
+It offers a streamlined, user-friendly way to create and manage your
+characters.
 
 ---
 
@@ -13,20 +15,36 @@ This is a digital character manager built specifically for **Exalted: Essence**.
 - **TypeScript**
 - Data stored locally in your browser (Local Storage)
 - All code generated with the help of AI
-- Code lives on [![Github](https://img.shields.io/badge/version-0.0.6-orange.svg)](https://github.com/AlexanderExter/exalted-charsheet/releases)
+- Code lives on  
+  [![GitHub][version-badge]][releases]
 
 ---
 
 ## Version
 
 **v0.0.6** — Dexie import persistence and server safeguards
-_Note: Features are subject to change. Export formats may break in future versions._
+_Note: Features are subject to change. Export formats may break in future
+versions._
+
+---
+
+## Buy Exalted Books
+
+Purchase official Exalted books through  
+[DriveThruRPG](https://www.drivethrurpg.com/browse/pub/10479/Onyx-Path-Publishing).
+
+## Official Discord
+
+Join the community on the  
+[Onyx Path Official Discord](https://discord.gg/theonyxpath).
 
 ---
 
 ## About the Creator
 
-I come from a Product Management background, not engineering. This app was coded entirely with the help of Claude Code and v0. As such, you may encounter varying levels of code quality and implementation.
+I come from a Product Management background, not engineering. This app was
+coded entirely with the help of Claude Code and v0, so you may encounter
+varying levels of code quality and implementation.
 
 Your feedback, suggestions, and bug reports are very welcome!  
 Contact: [exteralexander@gmail.com](mailto:exteralexander@gmail.com)
@@ -34,3 +52,6 @@ Contact: [exteralexander@gmail.com](mailto:exteralexander@gmail.com)
 ---
 
 _Happy gaming, and may your dice always explode!_
+
+[version-badge]: https://img.shields.io/badge/version-0.0.6-orange.svg
+[releases]: https://github.com/AlexanderExter/exalted-charsheet/releases

--- a/public/content/legal.md
+++ b/public/content/legal.md
@@ -4,103 +4,61 @@
 
 ## 1. Intellectual Property
 
-This application is an unofficial, fan-created tool for **Exalted: Essence**, a tabletop RPG published by **Onyx Path Publishing**. It is not affiliated with, endorsed by, or officially connected to Onyx Path Publishing.
-
-**Trademarks & Copyright:**
-
-- **Exalted** and **Exalted: Essence** are trademarks of Onyx Path Publishing.
-- All referenced game mechanics, terminology, and concepts belong to their respective copyright holders.
-- This app implements publicly available rules for personal use only.
+This unofficial fan tool is not affiliated with Onyx Path Publishing.  
+**Exalted** and **Exalted: Essence** are trademarks of Onyx Path Publishing.  
+Publicly available rules are implemented for personal use only.
 
 ---
 
 ## 2. Usage Terms
 
-**Personal Use Only:**
-
-- Free for personal, non-commercial use.
-- You may use the app to manage your own Exalted: Essence characters.
-- You may share character data files with your gaming group.
-
-**Restrictions:**
-
-- Commercial use is prohibited.
-- Redistribution or sale of the app is not allowed.
-- Do not claim ownership of the underlying game mechanics or IP.
-- Do not remove or alter copyright notices or disclaimers.
+The app is free for personal, non-commercial use.
+Sharing character files with your group is fine.
+Commercial use, redistribution, and claiming ownership of the game IP are
+prohibited.
 
 ---
 
 ## 3. Data Privacy & Security
 
-**Local Storage:**
-
-- All character data is stored locally in your browser.
-- No data is sent to external servers.
-- No user accounts, registration, or personal information is required.
-- Your data remains private and under your control.
-
-**Backup Responsibility:**
-
-- You are responsible for backing up your character data using the export feature.
-- Browser data may be lost due to clearing, updates, or system issues.
-- Regular exports are recommended to prevent data loss.
+All data lives in your browser's Local Storage and is never sent to a server.  
+Export regularly; you are responsible for your own backups.
 
 ---
 
 ## 4. Software License
 
-**Open Source Components:**
-
-- **Next.js** – MIT License
-- **React** – MIT License
-- **TypeScript** – Apache 2.0 License
-- **Tailwind CSS** – MIT License
-- **Radix UI** – MIT License
-- **Lucide Icons** – ISC License
-
-**Application Code:**
-
-- The source code for this app is provided under the MIT License.
-- You may use, modify, and distribute it for personal purposes with proper attribution.
+Open source components retain their respective licenses.
+This app's code is released under the MIT License for personal use with
+attribution.
 
 ---
 
 ## 5. Disclaimers
 
-- This software is provided "as is" without warranty of any kind.
-- Developed with the help of AI.
-- The creator does not own the ideas, rules, or games referenced.
-- This app is intended to comply with guidelines for Storypath Nexus, Canis Minor, and Storytellers Vault.
-- See the About section for contact information.
+Provided "as is" without warranty.  
+Developed with AI assistance.  
+See the About page for community links:  
+[Buy Exalted Books](/about#buy-exalted-books) •
+[Official Discord](/about#official-discord).
 
 ---
 
 ## 6. Updates & Changes
 
-**Application Updates:**
-
-- Updates may be released to fix bugs or add features.
-- No guarantee of update frequency.
-- Major changes will be documented in the changelog.
-- Breaking changes may occur until further notice.
-
-**Legal Terms:**
-
-- These terms may be updated periodically.
-- Continued use of the app means you accept updated terms.
-- Check this section regularly for changes.
+Features and terms may change.  
+Check the changelog and this page for updates.
 
 ---
 
 ## 7. Contact & Support
 
-- This is a community project maintained by volunteers.
-- Support is provided on a best-effort basis via community channels.
-- No guarantee of response time or issue resolution.
+Community maintained; responses are best effort via the  
+[Official Discord](/about#official-discord).
 
 ---
 
 **Last Updated:** July 2025
 
-_By using this application, you acknowledge that you have read, understood, and agree to these terms and disclaimers._
+_By using this application, you acknowledge that you have read, understood,
+and agree to these terms and disclaimers._


### PR DESCRIPTION
## Summary
- add community links for buying Exalted books and the official Discord
- rewrite legal text into concise sections with cross-links to community resources
- refactor GitHub badge link to avoid long markdown lines

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a44b830a08332a67e1254264cbdb3