### PR TITLE
chore: improve character store save comparisons

### DIFF
--- a/hooks/useCharacterStore.test.ts
+++ b/hooks/useCharacterStore.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  getAllCharacters: vi.fn().mockResolvedValue([]),
+  saveCharacter: vi.fn().mockResolvedValue(undefined),
+  deleteCharacter: vi.fn().mockResolvedValue(undefined),
+  getCurrentCharacterId: vi.fn().mockResolvedValue(null),
+  setCurrentCharacterId: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { useCharacterStore, waitForCharacterStoreSave } from "@/hooks/useCharacterStore";
+import { saveCharacter } from "@/lib/db";
+
+describe("useCharacterStore autosave", () => {
+  it("saves characters only when data changes", async () => {
+    // Ensure store initialization completes
+    await new Promise(res => setTimeout(res, 0));
+
+    useCharacterStore.getState().addCharacter("Test");
+    await waitForCharacterStoreSave();
+    expect(saveCharacter).toHaveBeenCalledTimes(1);
+
+    vi.mocked(saveCharacter).mockClear();
+
+    const currentName = useCharacterStore.getState().currentCharacter!.name;
+    useCharacterStore.getState().updateCurrentCharacter({ name: currentName });
+    await waitForCharacterStoreSave();
+    expect(saveCharacter).not.toHaveBeenCalled();
+
+    useCharacterStore.getState().updateCurrentCharacter({ name: "Updated" });
+    await waitForCharacterStoreSave();
+    expect(saveCharacter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/useCharacterStore.ts
+++ b/hooks/useCharacterStore.ts
@@ -1,8 +1,9 @@
-'use client';
+"use client";
 
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
+import isEqual from "fast-deep-equal";
 import { createNewCharacter } from "@/lib/character-defaults";
 import { CharacterSchema, type Character } from "@/lib/character-types";
 import {
@@ -75,8 +76,7 @@ export const useCharacterStore = create<CharacterState>()(
           getCurrentCharacterId(),
         ]);
         const parsed = CharacterSchema.array().parse(charsFromDB) as Character[];
-        const currentChar =
-          parsed.find(c => c.id === currentId) ?? parsed[0] ?? null;
+        const currentChar = parsed.find(c => c.id === currentId) ?? parsed[0] ?? null;
         set(state => {
           state.characters = parsed;
           state.currentCharacterId = currentChar?.id ?? null;
@@ -108,7 +108,7 @@ useCharacterStore.subscribe(
 
       for (const char of characters) {
         const prevChar = prevMap.get(char.id);
-        if (!prevChar || JSON.stringify(prevChar) !== JSON.stringify(char)) {
+        if (!prevChar || !isEqual(prevChar, char)) {
           operations.push(saveCharacterToDB(char));
         }
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "sync:version": "node scripts/sync-version.js",
     "version": "npm run sync:version",
     "// CI/CD": "Scripts for continuous integration",
-
     "ci:build": "npm run build:production",
     "ci:test": "npm run check:strict",
     "ci:lint": "npm run lint:strict",
@@ -81,6 +80,8 @@
     "@tanstack/react-table": "^8.20.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dexie": "^4.0.8",
+    "fast-deep-equal": "^3.1.3",
     "immer": "^10.1.1",
     "lucide-react": "^0.525.0",
     "next": "15.4.3",
@@ -93,8 +94,7 @@
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.0.2",
     "zod": "^4.0.17",
-    "zustand": "^5.0.0",
-    "dexie": "^4.0.8"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- use fast-deep-equal for detecting character changes
- add regression test to ensure saves only trigger on actual changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a452d93c48332afd38c1551a39456