### PR TITLE
feat: document incapacitation rules

### DIFF
--- a/components/combat/HealthTracker.tsx
+++ b/components/combat/HealthTracker.tsx
@@ -282,10 +282,32 @@ export const HealthTracker: React.FC<HealthTrackerProps> = ({
             {/* Incapacitation Rules */}
             {calculations.healthPenalty === -4 && (
               <div className="mt-3 border-t pt-3 bg-red-50 p-2 rounded">
-                <div className="text-xs font-medium text-red-700 mb-1">Incapacitation Rules:</div>
-                <div className="text-xs text-red-600">
-                  [Placeholder: Character is incapacitated and cannot take actions except for
-                  reflexive actions and one-die stunts]
+                <div className="text-xs font-medium text-red-700 mb-1">
+                  Incapacitation Rules:
+                </div>
+                <div className="text-xs text-red-600 space-y-1">
+                  <p>
+                    Incapacitated characters have their Power reduced to 0 and
+                    cannot Build Power or flurry. Allies can recover them by
+                    Building their Power to 10, which resets the track to 0.
+                  </p>
+                  <p>
+                    A player may ignore incapacitation by accepting a dramatic
+                    injury to an Attribute or Primary Merit, applying a -1 die
+                    penalty or losing access to that trait.
+                  </p>
+                  <p>
+                    See
+                    <a
+                      href="https://exalted.fandom.com/wiki/Exalted_Essence"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline ml-1"
+                    >
+                      Exalted Essence
+                    </a>
+                    for full rules.
+                  </p>
                 </div>
               </div>
             )}

--- a/components/combat/__tests__/HealthTracker.test.tsx
+++ b/components/combat/__tests__/HealthTracker.test.tsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { HealthTracker } from "@/components/combat/HealthTracker";
+import { createDefaultHealth } from "@/lib/character-defaults";
+import type { Character } from "@/lib/character-types";
+import type { CharacterCalculations } from "@/hooks/useCharacterCalculations";
+
+describe("HealthTracker", () => {
+  it("renders incapacitation rules snapshot", () => {
+    const character = { health: createDefaultHealth() } as unknown as Character;
+    const calculations = {
+      healthPenalty: -4,
+      healthLevels: { zero: 2, minusOne: 2, minusTwo: 2, incap: 1 },
+    } as unknown as CharacterCalculations;
+
+    const { container } = render(
+      <HealthTracker
+        character={character}
+        updateCharacter={() => {}}
+        calculations={calculations}
+        getTotalHealthLevels={() => 7}
+        addDramaticInjury={() => {}}
+        updateDramaticInjury={() => {}}
+        deleteDramaticInjury={() => {}}
+      />
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});
+

--- a/components/combat/__tests__/__snapshots__/HealthTracker.test.tsx.snap
+++ b/components/combat/__tests__/__snapshots__/HealthTracker.test.tsx.snap
@@ -1,0 +1,354 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`HealthTracker > renders incapacitation rules snapshot 1`] = `
+<div>
+  <div
+    class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm"
+    data-slot="card"
+  >
+    <div
+      class="@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6"
+      data-slot="card-header"
+    >
+      <div
+        class="leading-none font-semibold flex items-center justify-between"
+        data-slot="card-title"
+      >
+        Health Track
+        <div
+          class="flex items-center gap-4"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-600"
+              data-slot="label"
+            >
+              Exalt Type:
+            </label>
+            <button
+              aria-autocomplete="none"
+              aria-controls="radix-«r0»"
+              aria-expanded="false"
+              class="border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 w-28"
+              data-size="default"
+              data-slot="select-trigger"
+              data-state="closed"
+              dir="ltr"
+              role="combobox"
+              type="button"
+            >
+              <span
+                data-slot="select-value"
+                style="pointer-events: none;"
+              >
+                Lunar
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down size-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-6"
+      data-slot="card-content"
+    >
+      <div
+        class="space-y-4"
+      >
+        <div
+          class="grid grid-cols-2 md:grid-cols-4 gap-4"
+        >
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Zero Penalty
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              min="0"
+              type="number"
+              value="2"
+            />
+          </div>
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              -1 Penalty
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              min="0"
+              type="number"
+              value="2"
+            />
+          </div>
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              -2 Penalty
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              min="0"
+              type="number"
+              value="2"
+            />
+          </div>
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Incapacitated
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              min="0"
+              type="number"
+              value="1"
+            />
+          </div>
+        </div>
+        <div
+          class="mt-4"
+        >
+          <label
+            class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+            data-slot="label"
+          >
+            Ox-Body Levels (adds health levels)
+          </label>
+          <input
+            class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+            data-slot="input"
+            min="0"
+            type="number"
+            value="0"
+          />
+          <div
+            class="mt-3 p-2 bg-gray-50 rounded"
+          >
+            <div
+              class="grid grid-cols-4 gap-2 text-xs"
+            >
+              <div
+                class="text-center"
+              >
+                <div
+                  class="font-medium text-green-600"
+                >
+                  0 Penalty
+                </div>
+                <div
+                  class="text-lg font-bold"
+                >
+                  2
+                </div>
+              </div>
+              <div
+                class="text-center"
+              >
+                <div
+                  class="font-medium text-yellow-600"
+                >
+                  -1 Penalty
+                </div>
+                <div
+                  class="text-lg font-bold"
+                >
+                  2
+                </div>
+              </div>
+              <div
+                class="text-center"
+              >
+                <div
+                  class="font-medium text-orange-600"
+                >
+                  -2 Penalty
+                </div>
+                <div
+                  class="text-lg font-bold"
+                >
+                  2
+                </div>
+              </div>
+              <div
+                class="text-center"
+              >
+                <div
+                  class="font-medium text-red-600"
+                >
+                  Incapacitated
+                </div>
+                <div
+                  class="text-lg font-bold"
+                >
+                  1
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="mt-3 border-t pt-3 bg-red-50 p-2 rounded"
+          >
+            <div
+              class="text-xs font-medium text-red-700 mb-1"
+            >
+              Incapacitation Rules:
+            </div>
+            <div
+              class="text-xs text-red-600 space-y-1"
+            >
+              <p>
+                Incapacitated characters have their Power reduced to 0 and cannot Build Power or flurry. Allies can recover them by Building their Power to 10, which resets the track to 0.
+              </p>
+              <p>
+                A player may ignore incapacitation by accepting a dramatic injury to an Attribute or Primary Merit, applying a -1 die penalty or losing access to that trait.
+              </p>
+              <p>
+                See
+                <a
+                  class="underline ml-1"
+                  href="https://exalted.fandom.com/wiki/Exalted_Essence"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Exalted Essence
+                </a>
+                for full rules.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid grid-cols-3 gap-4"
+        >
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Bashing Damage
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              max="7"
+              min="0"
+              type="number"
+              value="0"
+            />
+          </div>
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Lethal Damage
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              max="7"
+              min="0"
+              type="number"
+              value="0"
+            />
+          </div>
+          <div>
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Aggravated Damage
+            </label>
+            <input
+              class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center"
+              data-slot="input"
+              max="7"
+              min="0"
+              type="number"
+              value="0"
+            />
+          </div>
+        </div>
+        <div
+          class="space-y-3"
+        >
+          <div
+            class="flex items-center justify-between"
+          >
+            <label
+              class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-sm font-medium text-gray-700"
+              data-slot="label"
+            >
+              Dramatic Injuries
+            </label>
+            <button
+              class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
+              data-slot="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-plus w-4 h-4 mr-1"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 12h14"
+                />
+                <path
+                  d="M12 5v14"
+                />
+              </svg>
+              Add Injury
+            </button>
+          </div>
+          <p
+            class="text-gray-500 italic text-sm"
+          >
+            No dramatic injuries.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- document incapacitation effects and recovery options in HealthTracker
- add snapshot test for incapacitation rules display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a51e33e988332b5669e278b1d0700