### PR TITLE
refactor: improve tab and combat typings

### DIFF
--- a/components/character-tabs/tabs-config.ts
+++ b/components/character-tabs/tabs-config.ts
@@ -17,11 +17,13 @@ import { SocialTab } from "./SocialTab";
 import { AdvancementTab } from "./AdvancementTab";
 import { RulingsTab } from "./RulingsTab";
 
+export interface TabProps {}
+
 export interface TabConfig {
   id: string;
   label: string;
   icon: LucideIcon;
-  component: React.ComponentType<any>;
+  component: React.ComponentType<TabProps>;
 }
 
 export const tabs: TabConfig[] = [

--- a/components/combat/DramaticInjuriesList.tsx
+++ b/components/combat/DramaticInjuriesList.tsx
@@ -4,14 +4,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { DramaticInjury } from "@/lib/character-types";
+import type { Draft } from "immer";
 
 interface DramaticInjuriesListProps {
   injuries: DramaticInjury[];
   addDramaticInjury: () => void;
-  updateDramaticInjury: (
+  updateDramaticInjury: <K extends keyof DramaticInjury>(
     id: string,
-    field: keyof DramaticInjury,
-    value: DramaticInjury[keyof DramaticInjury]
+    field: K,
+    value: Draft<DramaticInjury>[K]
   ) => void;
   deleteDramaticInjury: (id: string) => void;
 }

--- a/components/combat/HealthTracker.tsx
+++ b/components/combat/HealthTracker.tsx
@@ -19,6 +19,7 @@ import {
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations";
 import { DramaticInjuriesList } from "@/components/combat/DramaticInjuriesList";
 import { z } from "zod";
+import type { Draft } from "immer";
 
 interface HealthTrackerProps {
   character: Character;
@@ -26,10 +27,10 @@ interface HealthTrackerProps {
   calculations: CharacterCalculations;
   getTotalHealthLevels: () => number;
   addDramaticInjury: () => void;
-  updateDramaticInjury: (
+  updateDramaticInjury: <K extends keyof DramaticInjury>(
     id: string,
-    field: keyof DramaticInjury,
-    value: DramaticInjury[keyof DramaticInjury]
+    field: K,
+    value: Draft<DramaticInjury>[K]
   ) => void;
   deleteDramaticInjury: (id: string) => void;
 }

--- a/hooks/useCombat.ts
+++ b/hooks/useCombat.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { produce } from "immer";
+import { produce, type Draft } from "immer";
 import type { Character, DramaticInjury } from "@/lib/character-types";
 import type { CharacterCalculations } from "@/hooks/useCharacterCalculations";
 
@@ -43,13 +43,15 @@ export function useCombat({ character, updateCharacter, calculations }: UseComba
   }, [character, updateCharacter]);
 
   const updateDramaticInjury = useCallback(
-    (id: string, field: keyof DramaticInjury, value: DramaticInjury[keyof DramaticInjury]) => {
+    <K extends keyof DramaticInjury>(id: string, field: K, value: Draft<DramaticInjury>[K]) => {
       if (!character) return;
 
       const updatedHealth = produce(character.health, draft => {
-        const injury = draft.dramaticInjuries.find(inj => inj.id === id);
+        const injury = draft.dramaticInjuries.find(inj => inj.id === id) as
+          | Draft<DramaticInjury>
+          | undefined;
         if (injury) {
-          (injury as any)[field] = value;
+          injury[field] = value;
         }
       });
 


### PR DESCRIPTION
## Summary
- add explicit TabProps and type tab components with React.ComponentType
- use typed Draft<DramaticInjury> updates in combat hook and related components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a532533448332a18ee37bbff2678d