### PR TITLE
Ensure interactive components run on client

### DIFF
--- a/components/EssenceEditor.tsx
+++ b/components/EssenceEditor.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/character-tabs/AdvancementTab.tsx
+++ b/components/character-tabs/AdvancementTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Advancement Tab Component - Milestones and character progression management
 
 import React, { useCallback, useState } from "react";

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Combat Tab Component - Essence, health, static values, and combat mechanics
 
 import React from "react";

--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Core Stats Tab Component - Essence, attributes, abilities, and dice pool calculator
 
 import React from "react";

--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Equipment Tab Component - Armor, weapons, and equipment management
 
 import React, { useCallback } from "react";

--- a/components/character-tabs/PowersTab.tsx
+++ b/components/character-tabs/PowersTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Powers Tab Component - Charms and Spells management
 
 import React, { useCallback } from "react";

--- a/components/character-tabs/RulingsTab.tsx
+++ b/components/character-tabs/RulingsTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Rulings Tab Component - Character-specific rulings and house rules
 
 import React, { useCallback } from "react";

--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Social Tab Component - Virtues, intimacies, and resolve management
 
 import React, { useCallback } from "react";

--- a/components/character-tabs/common/EssencePanel.tsx
+++ b/components/character-tabs/common/EssencePanel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";

--- a/components/combat/CombatRolls.tsx
+++ b/components/combat/CombatRolls.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/components/combat/DramaticInjuriesList.tsx
+++ b/components/combat/DramaticInjuriesList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/components/combat/HealthTracker.tsx
+++ b/components/combat/HealthTracker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";

--- a/components/combat/StaticValuesPanel.tsx
+++ b/components/combat/StaticValuesPanel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { produce } from "immer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/components/equipment/ArmorEditor.tsx
+++ b/components/equipment/ArmorEditor.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/equipment/ArmorList.tsx
+++ b/components/equipment/ArmorList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/components/equipment/EquipmentTagReference.tsx
+++ b/components/equipment/EquipmentTagReference.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useMemo } from "react";
 import {
   ColumnDef,

--- a/components/equipment/WeaponEditor.tsx
+++ b/components/equipment/WeaponEditor.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/equipment/WeaponList.tsx
+++ b/components/equipment/WeaponList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/components/forms/AbilitySelector.tsx
+++ b/components/forms/AbilitySelector.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import {
   Select,

--- a/components/forms/AttributeSelector.tsx
+++ b/components/forms/AttributeSelector.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Button } from "@/components/ui/button";
 import {

--- a/components/forms/DicePoolEditor.tsx
+++ b/components/forms/DicePoolEditor.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import AttributeSelector from "./AttributeSelector";

--- a/components/forms/DicePoolSummary.tsx
+++ b/components/forms/DicePoolSummary.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useMemo } from "react";
 import { useCharacterContext } from "@/hooks/CharacterContext";
 

--- a/components/forms/ModifierInputs.tsx
+++ b/components/forms/ModifierInputs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { Input } from "@/components/ui/input";
 import {

--- a/components/forms/StatTable.tsx
+++ b/components/forms/StatTable.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import {
   ColumnDef,

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import {

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
@@ -19,11 +23,28 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"],
-      "@hookform/resolvers/zod": ["types/hookform-zod-module"],
-      "@hookform/resolvers/zod/dist/types": ["types/hookform-zod"]
-    }
+      "@/*": [
+        "./*"
+      ],
+      "@hookform/resolvers/zod": [
+        "types/hookform-zod-module"
+      ],
+      "@hookform/resolvers/zod/dist/types": [
+        "types/hookform-zod"
+      ]
+    },
+    "allowJs": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/__tests__"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__"
+  ]
 }


### PR DESCRIPTION
## Summary
- add `'use client'` directive to CoreStatsTab, CombatTab, EssencePanel, EssenceEditor, and other interactive components
- mark supporting UI, combat, equipment, and form components as client modules

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689a85d70b8c83329b729c44c5aa9bd9