### PR TITLE
Handle NaN inputs in EssenceEditor

### DIFF
--- a/components/EssenceEditor.tsx
+++ b/components/EssenceEditor.tsx
@@ -40,7 +40,11 @@ export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(({ essence
           type="number"
           value={rating}
           onChange={e => {
-            const value = Math.max(1, Math.min(5, Number.parseInt(e.target.value) || 0));
+            let value = parseInt(e.target.value, 10);
+            if (isNaN(value)) {
+              value = rating;
+            }
+            value = Math.max(1, Math.min(5, value));
             onChange({ ...essence, rating: value, motes: motesByEssence[value] ?? 0 });
           }}
           className="w-20 text-center"
@@ -58,7 +62,11 @@ export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(({ essence
           type="number"
           value={commitments}
           onChange={e => {
-            const value = Math.max(0, Number.parseInt(e.target.value) || 0);
+            let value = parseInt(e.target.value, 10);
+            if (isNaN(value)) {
+              value = 0;
+            }
+            value = Math.max(0, value);
             update("commitments", value);
           }}
           className="w-20 text-center"
@@ -71,7 +79,11 @@ export const EssenceEditor: React.FC<EssenceEditorProps> = React.memo(({ essence
           type="number"
           value={spent}
           onChange={e => {
-            const value = Math.max(0, Number.parseInt(e.target.value) || 0);
+            let value = parseInt(e.target.value, 10);
+            if (isNaN(value)) {
+              value = 0;
+            }
+            value = Math.max(0, value);
             update("spent", value);
           }}
           className="w-20 text-center"

--- a/components/__tests__/EssenceEditor.test.tsx
+++ b/components/__tests__/EssenceEditor.test.tsx
@@ -27,5 +27,39 @@ describe("EssenceEditor", () => {
       expect(motesRow.textContent).toContain("5");
     }
   });
+
+  it("updates remain and open when fields are cleared or retyped", () => {
+    const TestWrapper: React.FC = () => {
+      const [essence, setEssence] = React.useState(createDefaultEssence());
+      return <EssenceEditor essence={essence} onChange={setEssence} />;
+    };
+    render(<TestWrapper />);
+    const [ratingInput, commitmentsInput, spentInput] = screen.getAllByRole("spinbutton");
+    const remainRow = screen.getByText("Remain").closest("div") as HTMLElement;
+    const openRow = screen.getByText("Open").closest("div") as HTMLElement;
+    expect(remainRow).toHaveTextContent("5");
+    expect(openRow).toHaveTextContent("5");
+    fireEvent.change(commitmentsInput, { target: { value: "2" } });
+    expect(remainRow).toHaveTextContent("3");
+    expect(openRow).toHaveTextContent("3");
+    fireEvent.change(commitmentsInput, { target: { value: "" } });
+    expect(remainRow).toHaveTextContent("5");
+    expect(openRow).toHaveTextContent("5");
+    fireEvent.change(spentInput, { target: { value: "1" } });
+    expect(remainRow).toHaveTextContent("4");
+    expect(openRow).toHaveTextContent("5");
+    fireEvent.change(spentInput, { target: { value: "" } });
+    expect(remainRow).toHaveTextContent("5");
+    expect(openRow).toHaveTextContent("5");
+    fireEvent.change(ratingInput, { target: { value: "3" } });
+    expect(remainRow).toHaveTextContent("10");
+    expect(openRow).toHaveTextContent("10");
+    fireEvent.change(ratingInput, { target: { value: "" } });
+    expect(remainRow).toHaveTextContent("10");
+    expect(openRow).toHaveTextContent("10");
+    fireEvent.change(ratingInput, { target: { value: "4" } });
+    expect(remainRow).toHaveTextContent("12");
+    expect(openRow).toHaveTextContent("12");
+  });
 });
 


### PR DESCRIPTION
## Summary
- guard EssenceEditor numeric fields against NaN by using `parseInt` and defaults
- test that remain and open totals update when inputs are cleared or retyped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8ed070948332aff970a48cbc54e3