### PR TITLE
feat: add reusable sortable list component

### DIFF
--- a/components/character-tabs/AdvancementTab.tsx
+++ b/components/character-tabs/AdvancementTab.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import type { AdvancementEntry, AdvancementStatus } from "@/lib/character-types";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import { SortableList } from "@/components/common/SortableList";
 
 export const AdvancementTab: React.FC = React.memo(() => {
   const { character, updateCharacter } = useCharacterContext();
@@ -277,19 +278,20 @@ export const AdvancementTab: React.FC = React.memo(() => {
             {(character?.advancement || []).length === 0 ? (
               <p className="text-gray-500 italic">No advancement entries yet.</p>
             ) : (
-              <div className="space-y-4">
-                {(character?.advancement || []).map(entry => (
-                  <div
-                    key={entry.id}
-                    className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                  >
+              <SortableList
+                items={character?.advancement || []}
+                onReorder={items => updateCharacter({ advancement: items })}
+                renderItem={entry => (
+                  <>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                       <div>
                         <Label htmlFor={`entry-item-${entry.id}`}>Advancement Item</Label>
                         <Input
                           id={`entry-item-${entry.id}`}
                           value={entry.item}
-                          onChange={e => updateAdvancementEntry(entry.id, "item", e.target.value)}
+                          onChange={e =>
+                            updateAdvancementEntry(entry.id, "item", e.target.value)
+                          }
                           placeholder="e.g., Increase Awareness to 3, Learn Flying Blade Technique"
                         />
                       </div>
@@ -343,9 +345,9 @@ export const AdvancementTab: React.FC = React.memo(() => {
                         Delete
                       </Button>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  </>
+                )}
+              />
             )}
           </CardContent>
         )}

--- a/components/character-tabs/PowersTab.tsx
+++ b/components/character-tabs/PowersTab.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import type { Charm, Spell, SpellCircle } from "@/lib/character-types";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import { SortableList } from "@/components/common/SortableList";
 
 export const PowersTab: React.FC = React.memo(() => {
   const { character, updateCharacter } = useCharacterContext();
@@ -116,12 +117,11 @@ export const PowersTab: React.FC = React.memo(() => {
           {(character.charms || []).length === 0 ? (
             <p className="text-gray-500 italic">No charms yet.</p>
           ) : (
-            <div className="space-y-4">
-              {(character.charms || []).map(charm => (
-                <div
-                  key={charm.id}
-                  className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                >
+            <SortableList
+              items={character.charms || []}
+              onReorder={items => updateCharacter({ charms: items })}
+              renderItem={charm => (
+                <>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     <div>
                       <Label htmlFor={`charm-name-${charm.id}`}>Name</Label>
@@ -149,7 +149,11 @@ export const PowersTab: React.FC = React.memo(() => {
                       <Select
                         value={charm.step?.toString() || "none"}
                         onValueChange={value =>
-                          updateCharm(charm.id, "step", value === "none" ? null : parseInt(value))
+                          updateCharm(
+                            charm.id,
+                            "step",
+                            value === "none" ? null : parseInt(value)
+                          )
                         }
                       >
                         <SelectTrigger>
@@ -195,9 +199,9 @@ export const PowersTab: React.FC = React.memo(() => {
                       Delete
                     </Button>
                   </div>
-                </div>
-              ))}
-            </div>
+                </>
+              )}
+            />
           )}
         </CardContent>
       </Card>
@@ -217,12 +221,11 @@ export const PowersTab: React.FC = React.memo(() => {
           {(character.spells || []).length === 0 ? (
             <p className="text-gray-500 italic">No spells yet.</p>
           ) : (
-            <div className="space-y-4">
-              {(character.spells || []).map(spell => (
-                <div
-                  key={spell.id}
-                  className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                >
+            <SortableList
+              items={character.spells || []}
+              onReorder={items => updateCharacter({ spells: items })}
+              renderItem={spell => (
+                <>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     <div>
                       <Label htmlFor={`spell-name-${spell.id}`}>Name</Label>
@@ -314,9 +317,9 @@ export const PowersTab: React.FC = React.memo(() => {
                       Delete
                     </Button>
                   </div>
-                </div>
-              ))}
-            </div>
+                </>
+              )}
+            />
           )}
         </CardContent>
       </Card>

--- a/components/character-tabs/RulingsTab.tsx
+++ b/components/character-tabs/RulingsTab.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import type { Ruling } from "@/lib/character-types";
 import { useCharacterContext } from "@/hooks/CharacterContext";
+import { SortableList } from "@/components/common/SortableList";
 
 export const RulingsTab: React.FC = React.memo(() => {
   const { character, updateCharacter } = useCharacterContext();
@@ -72,12 +73,11 @@ export const RulingsTab: React.FC = React.memo(() => {
           {(character.rulings || []).length === 0 ? (
             <p className="text-gray-500 italic">No rulings recorded yet.</p>
           ) : (
-            <div className="space-y-4">
-              {(character.rulings || []).map(ruling => (
-                <div
-                  key={ruling.id}
-                  className="p-4 bg-white rounded border border-gray-200 space-y-3"
-                >
+            <SortableList
+              items={character.rulings || []}
+              onReorder={items => updateCharacter({ rulings: items })}
+              renderItem={ruling => (
+                <>
                   <div className="flex items-center gap-2">
                     <div className="flex-1">
                       <Label htmlFor={`title-${ruling.id}`}>Title</Label>
@@ -125,9 +125,9 @@ export const RulingsTab: React.FC = React.memo(() => {
                     />
                   </div>
                   <div className="text-xs text-gray-500">Created: {ruling.dateCreated}</div>
-                </div>
-              ))}
-            </div>
+                </>
+              )}
+            />
           )}
         </CardContent>
       </Card>

--- a/components/common/SortableList.tsx
+++ b/components/common/SortableList.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React from 'react';
+import { DndContext, type DragEndEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { GripVertical } from 'lucide-react';
+import clsx from 'clsx';
+import { CSS } from '@dnd-kit/utilities';
+
+interface SortableListProps<T extends { id: string }> {
+  items: T[];
+  onReorder: (items: T[]) => void;
+  renderItem: (item: T) => React.ReactNode;
+  className?: string;
+}
+
+interface SortableItemProps {
+  id: string;
+  children: React.ReactNode;
+}
+
+const SortableItem: React.FC<SortableItemProps> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={clsx(
+        'group relative rounded border border-gray-200 bg-white transition-colors',
+        'hover:bg-gray-50',
+        isDragging && 'z-50 shadow-lg'
+      )}
+    >
+      <button
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        className="absolute left-2 top-2 cursor-grab text-gray-400 hover:text-gray-600"
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <div className="pl-8 pr-4 py-4 space-y-3">{children}</div>
+    </div>
+  );
+};
+
+export const SortableList = <T extends { id: string }>({
+  items,
+  onReorder,
+  renderItem,
+  className,
+}: SortableListProps<T>) => {
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = items.findIndex(i => i.id === active.id);
+    const newIndex = items.findIndex(i => i.id === over.id);
+    if (oldIndex !== -1 && newIndex !== -1) {
+      onReorder(arrayMove(items, oldIndex, newIndex));
+    }
+  };
+
+  return (
+    <DndContext onDragEnd={handleDragEnd}>
+      <SortableContext items={items.map(i => i.id)} strategy={verticalListSortingStrategy}>
+        <div className={clsx('space-y-4', className)}>
+          {items.map(item => (
+            <SortableItem key={item.id} id={item.id}>
+              {renderItem(item)}
+            </SortableItem>
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+SortableList.displayName = 'SortableList';

--- a/components/equipment/ArmorEditor.tsx
+++ b/components/equipment/ArmorEditor.tsx
@@ -23,7 +23,7 @@ interface ArmorEditorProps {
 
 export const ArmorEditor: React.FC<ArmorEditorProps> = ({ armor, updateArmor, deleteArmor }) => {
   return (
-    <div className="p-4 bg-white rounded border border-gray-200 space-y-3">
+    <div className="space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         <div>
           <Label htmlFor={`armor-name-${armor.id}`}>Name</Label>

--- a/components/equipment/ArmorList.tsx
+++ b/components/equipment/ArmorList.tsx
@@ -6,13 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ArmorPiece } from "@/lib/character-types";
 import { ArmorEditor } from "@/components/equipment/ArmorEditor";
-import { DndContext, type DragEndEvent } from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { SortableList } from "@/components/common/SortableList";
 
 interface ArmorListProps {
   armor: ArmorPiece[];
@@ -22,25 +16,6 @@ interface ArmorListProps {
   reorderArmor: (armor: ArmorPiece[]) => void;
 }
 
-const SortableArmorItem: React.FC<{
-  piece: ArmorPiece;
-  updateArmor: (id: string, field: keyof ArmorPiece, value: ArmorPiece[keyof ArmorPiece]) => void;
-  deleteArmor: (id: string) => void;
-}> = ({ piece, updateArmor, deleteArmor }) => {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
-    id: piece.id,
-  });
-  const style: React.CSSProperties = {
-    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-    transition,
-  };
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <ArmorEditor armor={piece} updateArmor={updateArmor} deleteArmor={deleteArmor} />
-    </div>
-  );
-};
-
 export const ArmorList: React.FC<ArmorListProps> = ({
   armor,
   addArmor,
@@ -48,15 +23,6 @@ export const ArmorList: React.FC<ArmorListProps> = ({
   deleteArmor,
   reorderArmor,
 }) => {
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id) return;
-    const oldIndex = armor.findIndex(a => a.id === active.id);
-    const newIndex = armor.findIndex(a => a.id === over.id);
-    if (oldIndex !== -1 && newIndex !== -1) {
-      reorderArmor(arrayMove(armor, oldIndex, newIndex));
-    }
-  };
-
   return (
     <Card>
       <CardHeader>
@@ -72,20 +38,17 @@ export const ArmorList: React.FC<ArmorListProps> = ({
         {armor.length === 0 ? (
           <p className="text-gray-500 italic">No armor equipped.</p>
         ) : (
-          <DndContext onDragEnd={handleDragEnd}>
-            <SortableContext items={armor.map(a => a.id)} strategy={verticalListSortingStrategy}>
-              <div className="space-y-4">
-                {armor.map(piece => (
-                  <SortableArmorItem
-                    key={piece.id}
-                    piece={piece}
-                    updateArmor={updateArmor}
-                    deleteArmor={deleteArmor}
-                  />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
+          <SortableList
+            items={armor}
+            onReorder={reorderArmor}
+            renderItem={piece => (
+              <ArmorEditor
+                armor={piece}
+                updateArmor={updateArmor}
+                deleteArmor={deleteArmor}
+              />
+            )}
+          />
         )}
       </CardContent>
     </Card>

--- a/components/equipment/WeaponEditor.tsx
+++ b/components/equipment/WeaponEditor.tsx
@@ -27,7 +27,7 @@ export const WeaponEditor: React.FC<WeaponEditorProps> = ({
   deleteWeapon,
 }) => {
   return (
-    <div className="p-4 bg-white rounded border border-gray-200 space-y-3">
+    <div className="space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         <div>
           <Label htmlFor={`weapon-name-${weapon.id}`}>Name</Label>

--- a/components/equipment/WeaponList.tsx
+++ b/components/equipment/WeaponList.tsx
@@ -6,13 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Weapon } from "@/lib/character-types";
 import { WeaponEditor } from "@/components/equipment/WeaponEditor";
-import { DndContext, type DragEndEvent } from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { SortableList } from "@/components/common/SortableList";
 
 interface WeaponListProps {
   weapons: Weapon[];
@@ -22,25 +16,6 @@ interface WeaponListProps {
   reorderWeapons: (weapons: Weapon[]) => void;
 }
 
-const SortableWeaponItem: React.FC<{
-  weapon: Weapon;
-  updateWeapon: (id: string, field: keyof Weapon, value: Weapon[keyof Weapon]) => void;
-  deleteWeapon: (id: string) => void;
-}> = ({ weapon, updateWeapon, deleteWeapon }) => {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
-    id: weapon.id,
-  });
-  const style: React.CSSProperties = {
-    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-    transition,
-  };
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <WeaponEditor weapon={weapon} updateWeapon={updateWeapon} deleteWeapon={deleteWeapon} />
-    </div>
-  );
-};
-
 export const WeaponList: React.FC<WeaponListProps> = ({
   weapons,
   addWeapon,
@@ -48,15 +23,6 @@ export const WeaponList: React.FC<WeaponListProps> = ({
   deleteWeapon,
   reorderWeapons,
 }) => {
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id) return;
-    const oldIndex = weapons.findIndex(w => w.id === active.id);
-    const newIndex = weapons.findIndex(w => w.id === over.id);
-    if (oldIndex !== -1 && newIndex !== -1) {
-      reorderWeapons(arrayMove(weapons, oldIndex, newIndex));
-    }
-  };
-
   return (
     <Card>
       <CardHeader>
@@ -72,20 +38,17 @@ export const WeaponList: React.FC<WeaponListProps> = ({
         {weapons.length === 0 ? (
           <p className="text-gray-500 italic">No weapons equipped.</p>
         ) : (
-          <DndContext onDragEnd={handleDragEnd}>
-            <SortableContext items={weapons.map(w => w.id)} strategy={verticalListSortingStrategy}>
-              <div className="space-y-4">
-                {weapons.map(w => (
-                  <SortableWeaponItem
-                    key={w.id}
-                    weapon={w}
-                    updateWeapon={updateWeapon}
-                    deleteWeapon={deleteWeapon}
-                  />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
+          <SortableList
+            items={weapons}
+            onReorder={reorderWeapons}
+            renderItem={w => (
+              <WeaponEditor
+                weapon={w}
+                updateWeapon={updateWeapon}
+                deleteWeapon={deleteWeapon}
+              />
+            )}
+          />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- extract shared drag-and-drop list into `SortableList` component with drag handles and hover styling
- use new component for armor, weapons, advancement entries, charms, spells, and rulings
- keep UI consistent for all sortable collections

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a94a9eaec8332a12f278bc03931c2