### PR TITLE
chore: use flat ESLint plugin configs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,11 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import js from "@eslint/js";
+import nextPlugin from "@next/eslint-plugin-next";
+import reactPlugin from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettierConfig from "eslint-config-prettier";
+import globals from "globals";
 
 const eslintConfig = [
   // Global ignores
@@ -19,16 +17,31 @@ const eslintConfig = [
       "dist/**",
       "**/*.min.js",
       "**/*.d.ts",
-      "coverage/**"
-    ]
+      "coverage/**",
+    ],
   },
 
-  // Base Next.js configuration
-  ...compat.extends("next/core-web-vitals"),
+  // Base configs
+  js.configs.recommended,
+  nextPlugin.flatConfig.coreWebVitals,
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat["jsx-runtime"],
+  reactHooks.configs["recommended-latest"],
 
   // Enhanced configuration for all files
   {
     files: ["**/*.{js,jsx,ts,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
     rules: {
       // React Hooks
       "react-hooks/exhaustive-deps": "warn",
@@ -52,10 +65,9 @@ const eslintConfig = [
 
       // React specific
       "react/prop-types": "off", // Using TypeScript instead
-      "react/react-in-jsx-scope": "off", // Next.js doesn't require React import
       "react/self-closing-comp": "warn",
-      "react/jsx-boolean-value": ["warn", "never"]
-    }
+      "react/jsx-boolean-value": ["warn", "never"],
+    },
   },
 
   // Configuration files (Node.js style)
@@ -66,24 +78,27 @@ const eslintConfig = [
       globals: {
         process: "readonly",
         __dirname: "readonly",
-        __filename: "readonly"
-      }
-    }
+        __filename: "readonly",
+      },
+    },
   },
 
   // TypeScript specific overrides
   {
     files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tsParser,
+    },
+    plugins: { "@typescript-eslint": tsPlugin },
     rules: {
+      "no-undef": "off",
       "no-unused-vars": "off", // Handled by TypeScript compiler
-      // Note: @typescript-eslint rules would require additional configuration
-      // For now, relying on TypeScript compiler for type checking
-      "@typescript-eslint/no-unused-vars": "off" // Will be handled by tsc
-    }
+      "@typescript-eslint/no-unused-vars": "off", // Will be handled by tsc
+    },
   },
 
   // Prettier integration (must be last)
-  ...compat.extends("eslint-config-prettier")
+  prettierConfig,
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
## Summary
- replace FlatCompat with native plugin flat configs for Next.js, React, and Prettier
- configure globals, React settings, and TypeScript overrides in eslint.config.mjs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b54aafa648332ab3b6dea285cc72c