### PR TITLE
Rename defence field to defense

### DIFF
--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -62,7 +62,7 @@ export const EquipmentTab: React.FC = React.memo(() => {
       name: "",
       accuracy: 0,
       damage: 0,
-      defence: 0,
+      defense: 0,
       overwhelming: 0,
       range: "close",
       tags: [],

--- a/components/equipment/WeaponEditor.tsx
+++ b/components/equipment/WeaponEditor.tsx
@@ -63,12 +63,14 @@ export const WeaponEditor: React.FC<WeaponEditorProps> = ({
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
         <div>
-          <Label htmlFor={`weapon-defence-${weapon.id}`}>Defence</Label>
+          <Label htmlFor={`weapon-defense-${weapon.id}`}>Defense</Label>
           <Input
-            id={`weapon-defence-${weapon.id}`}
+            id={`weapon-defense-${weapon.id}`}
             type="number"
-            value={weapon.defence}
-            onChange={e => updateWeapon(weapon.id, "defence", Number.parseInt(e.target.value) || 0)}
+            value={weapon.defense}
+            onChange={e =>
+              updateWeapon(weapon.id, "defense", Number.parseInt(e.target.value) || 0)
+            }
           />
         </div>
         <div>

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -100,7 +100,7 @@ export const WeaponSchema = z.object({
   name: z.string(),
   accuracy: z.number(),
   damage: z.number(),
-  defence: z.number(),
+  defense: z.number(),
   overwhelming: z.number(),
   range: WeaponRangeSchema,
   tags: z.array(z.string()),


### PR DESCRIPTION
## Summary
- rename weapon `defence` property to `defense`
- update UI components and defaults to use `defense`
- remove legacy migration logic; storage and character store now parse character data directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b54d1a3b88332bce10e2a8f555ff6