### PR TITLE
Rename Socials tab to Social

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### User Interface
 
-- 📱 **7-Tab Organization** - Core Stats, Combat, Equipment, Powers, Socials, Advancement, Rulings
+- 📱 **7-Tab Organization** - Core Stats, Combat, Equipment, Powers, Social, Advancement, Rulings
 - 📱 **Mobile-Responsive Design** - Works across devices and screen sizes
 - 🎨 **Intuitive Interface** - Follows game terminology and logical organization
 - ⚡ **Real-Time Calculations** - All derived values update automatically

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ This is a Next.js 15 application using the App Router pattern for an Exalted: Es
 
 - `ExaltedCharacterManager` - Main application component handling character selection and management
 - `CharacterProvider` - Context provider wrapping character editing functionality
-- Tabbed interface with 7 main sections: Core Stats, Combat, Equipment, Powers, Socials, Advancement, Rulings
+- Tabbed interface with 7 main sections: Core Stats, Combat, Equipment, Powers, Social, Advancement, Rulings
 
 **Data Flow**:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 | **Combat**      | Battle mechanics       | Health, Dice pools, Static values |
 | **Equipment**   | Gear management        | Weapons, Armor, Tag references    |
 | **Powers**      | Magical abilities      | Charms, Spells, Descriptions      |
-| **Socials**     | Social mechanics       | Virtues, Intimacies, Resolve      |
+| **Social**      | Social mechanics       | Virtues, Intimacies, Resolve      |
 | **Advancement** | Character progression  | Milestones, XP tracking           |
 | **Rulings**     | GM decisions           | House rules, edge cases           |
 

--- a/components/character-tabs/tabs-config.ts
+++ b/components/character-tabs/tabs-config.ts
@@ -52,8 +52,8 @@ export const tabs: TabConfig[] = [
     component: PowersTab,
   },
   {
-    id: "socials",
-    label: "Socials",
+    id: "social",
+    label: "Social",
     icon: Users,
     component: SocialTab,
   },


### PR DESCRIPTION
## Summary
- Rename the Socials tab id to `social` and label to `Social`
- Update documentation references from "Socials" to "Social"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b62845bb4833285ee8569e67206c8