### PR TITLE
style: use double quotes for use client directives

### DIFF
--- a/components/EssenceEditor.tsx
+++ b/components/EssenceEditor.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Input } from "@/components/ui/input";

--- a/components/character-tabs/AdvancementTab.tsx
+++ b/components/character-tabs/AdvancementTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Advancement Tab Component - Milestones and character progression management
 

--- a/components/character-tabs/CombatTab.tsx
+++ b/components/character-tabs/CombatTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Combat Tab Component - Essence, health, static values, and combat mechanics
 

--- a/components/character-tabs/CoreStatsTab.tsx
+++ b/components/character-tabs/CoreStatsTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Core Stats Tab Component - Essence, attributes, abilities, and dice pool calculator
 

--- a/components/character-tabs/EquipmentTab.tsx
+++ b/components/character-tabs/EquipmentTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Equipment Tab Component - Armor, weapons, and equipment management
 

--- a/components/character-tabs/PowersTab.tsx
+++ b/components/character-tabs/PowersTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Powers Tab Component - Charms and Spells management
 

--- a/components/character-tabs/RulingsTab.tsx
+++ b/components/character-tabs/RulingsTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Rulings Tab Component - Character-specific rulings and house rules
 

--- a/components/character-tabs/SocialTab.tsx
+++ b/components/character-tabs/SocialTab.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 // Social Tab Component - Virtues, intimacies, and resolve management
 

--- a/components/character-tabs/common/EssencePanel.tsx
+++ b/components/character-tabs/common/EssencePanel.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/components/combat/CombatRolls.tsx
+++ b/components/combat/CombatRolls.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Button } from "@/components/ui/button";

--- a/components/combat/DramaticInjuriesList.tsx
+++ b/components/combat/DramaticInjuriesList.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Plus, Trash2 } from "lucide-react";

--- a/components/combat/HealthTracker.tsx
+++ b/components/combat/HealthTracker.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/components/combat/StaticValuesPanel.tsx
+++ b/components/combat/StaticValuesPanel.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { produce } from "immer";

--- a/components/common/SortableList.tsx
+++ b/components/common/SortableList.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from 'react';
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';

--- a/components/equipment/ArmorEditor.tsx
+++ b/components/equipment/ArmorEditor.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Input } from "@/components/ui/input";

--- a/components/equipment/ArmorList.tsx
+++ b/components/equipment/ArmorList.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Plus } from "lucide-react";

--- a/components/equipment/EquipmentTagReference.tsx
+++ b/components/equipment/EquipmentTagReference.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React, { useMemo } from "react";
 import {

--- a/components/equipment/WeaponEditor.tsx
+++ b/components/equipment/WeaponEditor.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Input } from "@/components/ui/input";

--- a/components/equipment/WeaponList.tsx
+++ b/components/equipment/WeaponList.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Plus } from "lucide-react";

--- a/components/forms/AbilitySelector.tsx
+++ b/components/forms/AbilitySelector.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import {

--- a/components/forms/AttributeSelector.tsx
+++ b/components/forms/AttributeSelector.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Button } from "@/components/ui/button";

--- a/components/forms/DicePoolEditor.tsx
+++ b/components/forms/DicePoolEditor.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/components/forms/DicePoolSummary.tsx
+++ b/components/forms/DicePoolSummary.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React, { useMemo } from "react";
 import { useCharacterContext } from "@/hooks/CharacterContext";

--- a/components/forms/ModifierInputs.tsx
+++ b/components/forms/ModifierInputs.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import { Input } from "@/components/ui/input";

--- a/components/forms/StatTable.tsx
+++ b/components/forms/StatTable.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import React from "react";
 import {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import * as React from "react";
 


### PR DESCRIPTION
## Summary
- use double quotes for "use client" directive across components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b6ea699688332a2542eaa10b9e305